### PR TITLE
Phase 0: enforce auth + ownership on routes; add /events/nearby & /users/me

### DIFF
--- a/backend/EventFiles/EventRoutes.js
+++ b/backend/EventFiles/EventRoutes.js
@@ -1,11 +1,38 @@
 import express from 'express';
 import eventServices from './EventServices.js';
+import { requireAuth, optionalAuth, requireSelf } from '../middleware/auth.js';
 
 const router = express.Router();
+
+// Per-user daily event creation cap (anti-spam). Disabled under tests.
+const DAILY_EVENT_LIMIT = 2;
 
 router.get('/', (req, res) => {
   res.send('Yes, events info is working');
 });
+
+// Authorization middleware: only the event's host may modify it. Runs after
+// requireAuth (needs req.userId).
+async function requireEventOwner(req, res, next) {
+  try {
+    const owner = await eventServices.getEventOwner(req.params.id);
+    if (!owner)
+      return res
+        .status(404)
+        .json({ success: false, message: 'Event not found' });
+    if (String(owner.host) !== req.userId)
+      return res.status(403).json({
+        success: false,
+        message: 'You are not allowed to modify this event',
+      });
+    next();
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: `Error in the server: ${error}`,
+    });
+  }
+}
 
 // Get all events
 router.get('/all', async (req, res) => {
@@ -55,6 +82,33 @@ router.get('/upcoming', async (req, res) => {
     });
 });
 
+// Get upcoming events near a point (indexed geo query), nearest first.
+// Query params: lng, lat (required), radius in meters (optional, default ~10mi).
+router.get('/nearby', optionalAuth, async (req, res) => {
+  const lng = parseFloat(req.query.lng);
+  const lat = parseFloat(req.query.lat);
+  const radius = parseFloat(req.query.radius);
+
+  if (Number.isNaN(lng) || Number.isNaN(lat)) {
+    return res.status(400).json({
+      success: false,
+      message: 'lng and lat query params are required',
+    });
+  }
+
+  const maxDistance = Number.isNaN(radius) ? 16093 : radius; // ~10 miles default
+
+  try {
+    const events = await eventServices.findNearbyEvents(lng, lat, maxDistance);
+    res.status(200).json({ success: true, data: events });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: `Error in the server: ${error}`,
+    });
+  }
+});
+
 // Get event by ID
 router.get('/:id', async (req, res) => {
   await eventServices
@@ -79,26 +133,40 @@ router.get('/:id', async (req, res) => {
     });
 });
 
-// Create new event
-router.post('/', async (req, res) => {
-  await eventServices
-    .addEvent(req.body)
-    .then((event) => {
-      res.status(201).json({
-        success: true,
-        data: event,
-      });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
-      });
+// Create new event (auth required). Host is taken from the token, never the
+// body, and a per-user daily creation cap guards against spam.
+router.post('/', requireAuth, async (req, res) => {
+  try {
+    if (process.env.NODE_ENV !== 'test') {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
+      const todayCount = await eventServices.countEventsByHostSince(
+        req.userId,
+        startOfDay
+      );
+      if (todayCount >= DAILY_EVENT_LIMIT) {
+        return res.status(429).json({
+          success: false,
+          message: `Daily event creation limit reached (${DAILY_EVENT_LIMIT} per day).`,
+        });
+      }
+    }
+
+    const event = await eventServices.addEvent({
+      ...req.body,
+      host: req.userId,
     });
+    res.status(201).json({ success: true, data: event });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: `Error in the server: ${error}`,
+    });
+  }
 });
 
-// Delete event
-router.delete('/:id', async (req, res) => {
+// Delete event (host only)
+router.delete('/:id', requireAuth, requireEventOwner, async (req, res) => {
   await eventServices
     .deleteEvent(req.params.id)
     .then((deletedEvent) => {
@@ -121,8 +189,8 @@ router.delete('/:id', async (req, res) => {
     });
 });
 
-// Update event
-router.put('/:id', async (req, res) => {
+// Update event (host only)
+router.put('/:id', requireAuth, requireEventOwner, async (req, res) => {
   await eventServices
     .updateEvent(req.params.id, req.body)
     .then((event) => {
@@ -421,100 +489,120 @@ router.get('/search/blocked/:userId', async (req, res) => {
     });
 });
 
-// Add user to attendees
-router.put('/:id/attendees/add/:userId', async (req, res) => {
-  await eventServices
-    .addUserToAttendees(req.params.id, req.params.userId)
-    .then((event) => {
-      if (!event)
-        res.status(404).json({
+// Add user to attendees (you can only RSVP yourself)
+router.put(
+  '/:id/attendees/add/:userId',
+  requireAuth,
+  requireSelf('userId'),
+  async (req, res) => {
+    await eventServices
+      .addUserToAttendees(req.params.id, req.params.userId)
+      .then((event) => {
+        if (!event)
+          res.status(404).json({
+            success: false,
+            message: 'Event not found',
+          });
+        else
+          res.status(200).json({
+            success: true,
+            data: event,
+          });
+      })
+      .catch((error) => {
+        res.status(500).json({
           success: false,
-          message: 'Event not found',
+          message: `Error in the server: ${error}`,
         });
-      else
-        res.status(200).json({
-          success: true,
-          data: event,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
       });
-    });
-});
+  }
+);
 
-// Remove user from attendees
-router.put('/:id/attendees/remove/:userId', async (req, res) => {
-  await eventServices
-    .removeUserFromAttendees(req.params.id, req.params.userId)
-    .then((event) => {
-      if (!event)
-        res.status(404).json({
+// Remove user from attendees (you can only un-RSVP yourself)
+router.put(
+  '/:id/attendees/remove/:userId',
+  requireAuth,
+  requireSelf('userId'),
+  async (req, res) => {
+    await eventServices
+      .removeUserFromAttendees(req.params.id, req.params.userId)
+      .then((event) => {
+        if (!event)
+          res.status(404).json({
+            success: false,
+            message: 'Event not found',
+          });
+        else
+          res.status(200).json({
+            success: true,
+            data: event,
+          });
+      })
+      .catch((error) => {
+        res.status(500).json({
           success: false,
-          message: 'Event not found',
+          message: `Error in the server: ${error}`,
         });
-      else
-        res.status(200).json({
-          success: true,
-          data: event,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
       });
-    });
-});
+  }
+);
 
-// Add user to blocked users
-router.put('/:id/blocked/add/:userId', async (req, res) => {
-  await eventServices
-    .addUserToBlocked(req.params.id, req.params.userId)
-    .then((event) => {
-      if (!event)
-        res.status(404).json({
+// Add user to blocked users (host only)
+router.put(
+  '/:id/blocked/add/:userId',
+  requireAuth,
+  requireEventOwner,
+  async (req, res) => {
+    await eventServices
+      .addUserToBlocked(req.params.id, req.params.userId)
+      .then((event) => {
+        if (!event)
+          res.status(404).json({
+            success: false,
+            message: 'Event not found',
+          });
+        else
+          res.status(200).json({
+            success: true,
+            data: event,
+          });
+      })
+      .catch((error) => {
+        res.status(500).json({
           success: false,
-          message: 'Event not found',
+          message: `Error in the server: ${error}`,
         });
-      else
-        res.status(200).json({
-          success: true,
-          data: event,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
       });
-    });
-});
+  }
+);
 
-// Remove user from blocked users
-router.put('/:id/blocked/remove/:userId', async (req, res) => {
-  await eventServices
-    .removeUserFromBlocked(req.params.id, req.params.userId)
-    .then((event) => {
-      if (!event)
-        res.status(404).json({
+// Remove user from blocked users (host only)
+router.put(
+  '/:id/blocked/remove/:userId',
+  requireAuth,
+  requireEventOwner,
+  async (req, res) => {
+    await eventServices
+      .removeUserFromBlocked(req.params.id, req.params.userId)
+      .then((event) => {
+        if (!event)
+          res.status(404).json({
+            success: false,
+            message: 'Event not found',
+          });
+        else
+          res.status(200).json({
+            success: true,
+            data: event,
+          });
+      })
+      .catch((error) => {
+        res.status(500).json({
           success: false,
-          message: 'Event not found',
+          message: `Error in the server: ${error}`,
         });
-      else
-        res.status(200).json({
-          success: true,
-          data: event,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
       });
-    });
-});
+  }
+);
 
 export default router;

--- a/backend/EventFiles/EventServices.js
+++ b/backend/EventFiles/EventServices.js
@@ -73,6 +73,34 @@ function findEventByInterests(interests) {
     .populate('attendees host blockedUsers');
 }
 
+// Find upcoming events near a point, nearest-first, using the 2dsphere index.
+// coordinates are [lng, lat]; maxDistanceMeters bounds the search radius.
+function findNearbyEvents(lng, lat, maxDistanceMeters, futureOnly = true) {
+  const query = {
+    location: {
+      $near: {
+        $geometry: { type: 'Point', coordinates: [lng, lat] },
+        $maxDistance: maxDistanceMeters,
+      },
+    },
+  };
+  if (futureOnly) query['time.start'] = { $gte: new Date() };
+  return eventModel.find(query).populate('attendees host blockedUsers');
+}
+
+// Lightweight owner lookup for authorization checks (no populate).
+function getEventOwner(id) {
+  return eventModel.findById(id).select('host').lean();
+}
+
+// Count events created by a host since a given time (per-user daily cap).
+function countEventsByHostSince(hostId, since) {
+  return eventModel.countDocuments({
+    host: hostId,
+    createdAt: { $gte: since },
+  });
+}
+
 // Find event(s) near a location (latitude, longitude, radius in miles)
 function findEventByLocation(latitude, longitude, radiusInMiles) {
   return eventModel
@@ -168,6 +196,9 @@ export default {
   addEvent,
   deleteEvent,
   updateEvent,
+  findNearbyEvents,
+  getEventOwner,
+  countEventsByHostSince,
   findEventById,
   findEventByName,
   findEventByDescription,

--- a/backend/UserFiles/UserRoutes.js
+++ b/backend/UserFiles/UserRoutes.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import userServices from './UserServices.js';
 import jwt from 'jsonwebtoken';
+import { requireAuth, requireSelf } from '../middleware/auth.js';
+import { authLimiter } from '../middleware/security.js';
 
 const router = express.Router();
 
@@ -8,8 +10,8 @@ router.get('/', (req, res) => {
   res.send('Yes, user info is working');
 });
 
-// Get all users
-router.get('/all', async (req, res) => {
+// Get all users (auth required — avoid dumping every user's PII anonymously)
+router.get('/all', requireAuth, async (req, res) => {
   await userServices
     .getUsers()
     .then((users) => {
@@ -31,7 +33,7 @@ router.get('/all', async (req, res) => {
 /*
  * Endpoint for USER LOGIN
  */
-router.post('/login', async (req, res) => {
+router.post('/login', authLimiter, async (req, res) => {
   const { email, password } = req.body;
 
   if (!email || !password)
@@ -72,7 +74,7 @@ router.post('/login', async (req, res) => {
  * Takes user data and password, creates new user in database
  */
 
-router.post('/', async (req, res) => {
+router.post('/', authLimiter, async (req, res) => {
   try {
     const newUser = await userServices.addUser(req.body);
 
@@ -114,7 +116,7 @@ router.post('/', async (req, res) => {
  * Endpoint for DELETE USER
  */
 
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', requireAuth, requireSelf('id'), async (req, res) => {
   await userServices
     .deleteUser(req.params.id)
     .then((deletedUser) => {
@@ -205,8 +207,8 @@ router.post('/logout', (req, res) => {
   });
 });
 
-// Update a user
-router.put('/:id', async (req, res) => {
+// Update a user (self only)
+router.put('/:id', requireAuth, requireSelf('id'), async (req, res) => {
   await userServices
     .updateUser(req.params.id, req.body)
     .then((user) => {
@@ -225,6 +227,24 @@ router.put('/:id', async (req, res) => {
       res.status(500).json({
         success: false,
         message: `Error in the server: ${error}`,
+      });
+    });
+});
+
+// Get the currently authenticated user. Must be declared before '/:id' so
+// '/me' isn't captured as an id param.
+router.get('/me', requireAuth, async (req, res) => {
+  await userServices
+    .findUserById(req.userId)
+    .then((user) => {
+      if (!user)
+        res.status(404).json({ success: false, message: 'User not found' });
+      else res.status(200).json({ success: true, data: user });
+    })
+    .catch((error) => {
+      res.status(500).json({
+        success: false,
+        message: `Error in the server: ${error.message}`,
       });
     });
 });
@@ -446,30 +466,6 @@ router.get('/search/location/:location', async (req, res) => {
       res.status(500).json({
         success: false,
         message: `Error in the server: ${error}`,
-      });
-    });
-});
-
-// Get a user by ID
-router.get('/:id', async (req, res) => {
-  await userServices
-    .findUserById(req.params.id)
-    .then((user) => {
-      if (!user)
-        res.status(404).json({
-          success: false,
-          message: 'User not found',
-        });
-      else
-        res.status(200).json({
-          success: true,
-          data: user,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error.message}`,
       });
     });
 });

--- a/frontend/src/Components/CreateEventModal/CreateEventModal.jsx
+++ b/frontend/src/Components/CreateEventModal/CreateEventModal.jsx
@@ -144,7 +144,10 @@ export default function CreateEventModal({ isOpen, onClose, onSuccess }) {
         `${import.meta.env.VITE_API_BASE_URL}/events/`,
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${user.token}`,
+          },
           body: JSON.stringify(payload),
         }
       );

--- a/frontend/src/Pages/Profile/Profile.jsx
+++ b/frontend/src/Pages/Profile/Profile.jsx
@@ -141,7 +141,10 @@ export default function Profile() {
         `${import.meta.env.VITE_API_BASE_URL}/users/${user.id}`,
         {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${user.token}`,
+          },
           body: JSON.stringify({
             name,
             phoneNumber,

--- a/tests/Integration/Events/event.routes.test.js
+++ b/tests/Integration/Events/event.routes.test.js
@@ -2,13 +2,17 @@ import request from 'supertest';
 import app from '../../../backend/backend.js';
 import eventModel from '../../../backend/EventFiles/EventSchema.js';
 import mongoose from 'mongoose';
+import { authHeader } from '../../helpers/auth.js';
+
+// Fixed host id so token-based ownership checks line up with created events.
+const TEST_HOST = new mongoose.Types.ObjectId();
 
 const testEvent = {
   name: 'Tech Meetup 2025',
   description: 'Testing',
   mapComponent: 'TechHall-1',
   attendees: [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()],
-  host: new mongoose.Types.ObjectId(),
+  host: TEST_HOST,
   blockedUsers: [new mongoose.Types.ObjectId()],
   comment: ['Looking forward to this!', 'Excited!'],
   address: '123 Blah, Pyongyang, North Korea',
@@ -53,13 +57,19 @@ describe('Event Routes', () => {
   });
 
   test('POST /events creates an event', async () => {
-    const res = await request(app).post('/events').send(testEvent);
+    const res = await request(app)
+      .post('/events')
+      .set(authHeader(TEST_HOST))
+      .send(testEvent);
     expect(res.status).toBe(201);
     expect(res.body.data.name).toBe('Tech Meetup 2025');
   });
 
   test('POST /events with invalid data fails', async () => {
-    const res = await request(app).post('/events').send({});
+    const res = await request(app)
+      .post('/events')
+      .set(authHeader(TEST_HOST))
+      .send({});
     expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
@@ -80,6 +90,7 @@ describe('Event Routes', () => {
     const created = await eventModel.create(testEvent);
     const res = await request(app)
       .put(`/events/${created._id}`)
+      .set(authHeader(TEST_HOST))
       .send({ description: 'Updated description' });
     expect(res.status).toBe(200);
     expect(res.body.data.description).toBe('Updated description');
@@ -89,13 +100,16 @@ describe('Event Routes', () => {
     const fakeId = new mongoose.Types.ObjectId();
     const res = await request(app)
       .put(`/events/${fakeId}`)
+      .set(authHeader(TEST_HOST))
       .send({ description: 'Update' });
     expect(res.status).toBe(404);
   });
 
   test('DELETE /events/:id deletes the event', async () => {
     const created = await eventModel.create(testEvent);
-    const res = await request(app).delete(`/events/${created._id}`);
+    const res = await request(app)
+      .delete(`/events/${created._id}`)
+      .set(authHeader(TEST_HOST));
     expect(res.status).toBe(200);
     const deleted = await eventModel.findById(created._id);
     expect(deleted).toBeNull();
@@ -103,7 +117,9 @@ describe('Event Routes', () => {
 
   test('DELETE /events/:id returns 404 for non-existent event', async () => {
     const fakeId = new mongoose.Types.ObjectId();
-    const res = await request(app).delete(`/events/${fakeId}`);
+    const res = await request(app)
+      .delete(`/events/${fakeId}`)
+      .set(authHeader(TEST_HOST));
     expect(res.status).toBe(404);
   });
 
@@ -242,9 +258,9 @@ describe('Event Routes', () => {
     const created = await eventModel.create(testEvent);
     const newUserId = new mongoose.Types.ObjectId();
 
-    const res = await request(app).put(
-      `/events/${created._id}/attendees/add/${newUserId}`
-    );
+    const res = await request(app)
+      .put(`/events/${created._id}/attendees/add/${newUserId}`)
+      .set(authHeader(newUserId));
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -258,9 +274,9 @@ describe('Event Routes', () => {
       attendees: [attendeeId],
     });
 
-    const res = await request(app).put(
-      `/events/${created._id}/attendees/remove/${attendeeId}`
-    );
+    const res = await request(app)
+      .put(`/events/${created._id}/attendees/remove/${attendeeId}`)
+      .set(authHeader(attendeeId));
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -271,9 +287,9 @@ describe('Event Routes', () => {
     const created = await eventModel.create(testEvent);
     const newBlockedId = new mongoose.Types.ObjectId();
 
-    const res = await request(app).put(
-      `/events/${created._id}/blocked/add/${newBlockedId}`
-    );
+    const res = await request(app)
+      .put(`/events/${created._id}/blocked/add/${newBlockedId}`)
+      .set(authHeader(TEST_HOST));
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -287,9 +303,9 @@ describe('Event Routes', () => {
       blockedUsers: [blockedUserId],
     });
 
-    const res = await request(app).put(
-      `/events/${created._id}/blocked/remove/${blockedUserId}`
-    );
+    const res = await request(app)
+      .put(`/events/${created._id}/blocked/remove/${blockedUserId}`)
+      .set(authHeader(TEST_HOST));
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -347,36 +363,36 @@ describe('Event Routes', () => {
   test('PUT /events/:id/attendees/add/:userId returns 404 when event not found', async () => {
     const fakeId = new mongoose.Types.ObjectId();
     const userId = new mongoose.Types.ObjectId();
-    const res = await request(app).put(
-      `/events/${fakeId}/attendees/add/${userId}`
-    );
+    const res = await request(app)
+      .put(`/events/${fakeId}/attendees/add/${userId}`)
+      .set(authHeader(userId));
     expect(res.status).toBe(404);
   });
 
   test('PUT /events/:id/attendees/remove/:userId returns 404 when event not found', async () => {
     const fakeId = new mongoose.Types.ObjectId();
     const userId = new mongoose.Types.ObjectId();
-    const res = await request(app).put(
-      `/events/${fakeId}/attendees/remove/${userId}`
-    );
+    const res = await request(app)
+      .put(`/events/${fakeId}/attendees/remove/${userId}`)
+      .set(authHeader(userId));
     expect(res.status).toBe(404);
   });
 
   test('PUT /events/:id/blocked/add/:userId returns 404 when event not found', async () => {
     const fakeId = new mongoose.Types.ObjectId();
     const userId = new mongoose.Types.ObjectId();
-    const res = await request(app).put(
-      `/events/${fakeId}/blocked/add/${userId}`
-    );
+    const res = await request(app)
+      .put(`/events/${fakeId}/blocked/add/${userId}`)
+      .set(authHeader(TEST_HOST));
     expect(res.status).toBe(404);
   });
 
   test('PUT /events/:id/blocked/remove/:userId returns 404 when event not found', async () => {
     const fakeId = new mongoose.Types.ObjectId();
     const userId = new mongoose.Types.ObjectId();
-    const res = await request(app).put(
-      `/events/${fakeId}/blocked/remove/${userId}`
-    );
+    const res = await request(app)
+      .put(`/events/${fakeId}/blocked/remove/${userId}`)
+      .set(authHeader(TEST_HOST));
     expect(res.status).toBe(404);
   });
 

--- a/tests/Integration/Users/user.routes.test.js
+++ b/tests/Integration/Users/user.routes.test.js
@@ -2,6 +2,7 @@ import request from 'supertest';
 import app from '../../../backend/backend.js';
 import userModel from '../../../backend/UserFiles/UserSchema.js';
 import mongoose from 'mongoose';
+import { authHeader } from '../../helpers/auth.js';
 
 const testUser = {
   name: 'Test User',
@@ -46,16 +47,25 @@ describe('User Routes', () => {
   });
 
   test('GET /users/all returns 404 when no users exist', async () => {
-    const res = await request(app).get('/users/all');
+    const res = await request(app)
+      .get('/users/all')
+      .set(authHeader(new mongoose.Types.ObjectId()));
     expect(res.statusCode).toBe(404);
     expect(res.body.success).toBe(false);
   });
 
   test('GET /users/all returns all users successfully', async () => {
     await request(app).post('/users').send(testUser);
-    const res = await request(app).get('/users/all');
+    const res = await request(app)
+      .get('/users/all')
+      .set(authHeader(new mongoose.Types.ObjectId()));
     expect(res.statusCode).toBe(200);
     expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  test('GET /users/all requires authentication', async () => {
+    const res = await request(app).get('/users/all');
+    expect(res.status).toBe(401);
   });
 
   describe('Authentication Tests', () => {
@@ -230,16 +240,29 @@ describe('User Routes', () => {
       const registerRes = await request(app).post('/users').send(testUser);
       const userId = registerRes.body.user._id;
 
-      const res = await request(app).delete(`/users/${userId}`);
+      const res = await request(app)
+        .delete(`/users/${userId}`)
+        .set(authHeader(userId));
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
     });
 
-    test('DELETE /users/:id returns 404 when user does not exist', async () => {
+    test('DELETE /users/:id forbids deleting another account', async () => {
+      const registerRes = await request(app).post('/users').send(testUser);
+      const userId = registerRes.body.user._id;
+      const otherId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .delete(`/users/${otherId}`)
+        .set(authHeader(userId));
+      expect(res.status).toBe(403);
+    });
+
+    test('DELETE /users/:id requires authentication', async () => {
       const res = await request(app).delete(
         `/users/${new mongoose.Types.ObjectId()}`
       );
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(401);
     });
 
     test('PUT /users/:id updates a user', async () => {
@@ -248,18 +271,24 @@ describe('User Routes', () => {
 
       const res = await request(app)
         .put(`/users/${userId}`)
+        .set(authHeader(userId))
         .send({ name: 'Updated Name' });
 
       expect(res.status).toBe(200);
       expect(res.body.data.name).toBe('Updated Name');
     });
 
-    test('PUT /users/:id returns 404 when updating nonexistent user', async () => {
+    test('PUT /users/:id forbids updating another account', async () => {
+      const registerRes = await request(app).post('/users').send(testUser);
+      const userId = registerRes.body.user._id;
+      const otherId = new mongoose.Types.ObjectId();
+
       const res = await request(app)
-        .put(`/users/${new mongoose.Types.ObjectId()}`)
+        .put(`/users/${otherId}`)
+        .set(authHeader(userId))
         .send({ name: 'Nope' });
 
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(403);
     });
   });
 

--- a/tests/helpers/auth.js
+++ b/tests/helpers/auth.js
@@ -1,0 +1,14 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Build an Authorization header with a signed access token for tests.
+ * requireAuth only verifies the signature, so the id need not be a real user.
+ * @param {string|object} userId
+ * @returns {{ Authorization: string }}
+ */
+export function authHeader(userId) {
+  const token = jwt.sign({ id: String(userId) }, process.env.JWT_TOKEN_SECRET, {
+    expiresIn: '15m',
+  });
+  return { Authorization: `Bearer ${token}` };
+}


### PR DESCRIPTION
## What & why

Completes Phase 0 by closing the **critical security hole**: previously any caller could `DELETE`/`PUT` **any** user or event (account takeover, event tampering). This wires the `requireAuth`/`requireSelf` middleware (from #118) onto every mutating route, plus the auth-unification-adjacent endpoints.

## Backend

**Events**
- `POST /events` — auth required; **host taken from the token, never the body**; per-user **daily creation cap (2/day)**, disabled under tests.
- `PUT`/`DELETE /events/:id` — auth + **host-only** ownership (`requireEventOwner`).
- `attendees add/remove` — auth + **you can only RSVP yourself** (`requireSelf` on `:userId`).
- `blocked add/remove` — auth + host-only.
- **`GET /events/nearby?lng&lat&radius`** — indexed `$near` geo query (nearest-first, upcoming only). The scalable "events near me" endpoint that replaces loading all events client-side.

**Users**
- `PUT`/`DELETE /users/:id` — auth + **self-only**. Closes account takeover.
- `GET /users/all` — auth required (was dumping every user's PII anonymously).
- **`GET /users/me`** — new; current user from token.
- `login`/`register` — `authLimiter` brute-force throttle.
- Removed dead duplicate `GET /:id`.
- `GET /users/:id` stays **public** (event cards render host names); a public-safe PII projection is deferred to Phase 4.

## Frontend
Added `Authorization` to the two write paths missing it (`CreateEventModal` create, `Profile` update). RSVP/delete paths already sent tokens.

## Tests
- New `tests/helpers/auth.js` (signs a test access token).
- Event/user integration tests now authenticate mutating routes.
- "non-existent → 404" delete/update cases converted to the new **"another account → 403"** semantics; added 401-without-auth cases.

## Verification
- ✅ Frontend unit suite green (163 passing).
- ✅ Foreground supertest smoke run against in-memory Mongo: 11/11 — confirms 401 without auth, 403 for non-owners, 200 for owners, host-from-token, `/events/nearby`, `/users/me`.
- CI runs the full integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)