### PR TITLE
Phase 1: live event preview on landing + public Explore page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import RegistrationModal from './Components/Modals/RegistrationModal/Registratio
 import { AuthProvider } from './Components/AuthProvider.jsx';
 import { ModalProvider, useModal } from './Components/ModalContext.jsx';
 import LandingPage from './Pages/Landing/Landing.jsx';
+import ExplorePage from './Pages/Explore/Explore.jsx';
 import Profile from './Pages/Profile/Profile.jsx';
 import ProtectedRoute from './Components/ProtectedComponent.jsx';
 import EventDetails from './Pages/EventDetails/EventDetails.jsx';
@@ -32,6 +33,7 @@ function AppContent() {
       <main className="main">
         <Routes>
           <Route path="/" element={<LandingPage />} />
+          <Route path="/explore" element={<ExplorePage />} />
           <Route path="/home" element={<HomePage />} />
           <Route
             path="/profile"

--- a/frontend/src/Components/LandingEventPreview/LandingEventPreview.css
+++ b/frontend/src/Components/LandingEventPreview/LandingEventPreview.css
@@ -1,0 +1,84 @@
+.lep-section {
+  width: min(1200px, 92%);
+  margin: 0 auto;
+  padding: 4rem 0 2rem;
+}
+
+.lep-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.lep-header h2 {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  margin: 0 0 0.5rem;
+}
+
+.lep-header p {
+  color: #5f6b7a;
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.lep-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.lep-skeleton {
+  height: 230px;
+  border-radius: 14px;
+  background: linear-gradient(100deg, #eef1f5 30%, #f7f9fb 50%, #eef1f5 70%);
+  background-size: 200% 100%;
+  animation: lep-shimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes lep-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.lep-empty {
+  text-align: center;
+  color: #5f6b7a;
+  padding: 2rem 0;
+}
+
+.lep-cta {
+  display: flex;
+  justify-content: center;
+  margin-top: 2.5rem;
+}
+
+.lep-explore-btn {
+  display: inline-block;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  background: #1f6feb;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.lep-explore-btn:hover {
+  background: #1a5fd0;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 640px) {
+  .lep-section {
+    padding: 2.5rem 0 1rem;
+  }
+  .lep-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/Components/LandingEventPreview/LandingEventPreview.jsx
+++ b/frontend/src/Components/LandingEventPreview/LandingEventPreview.jsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router-dom';
+import { useUpcomingEvents } from '../../Hooks/UseEvents.jsx';
+import EventComponent from '../EventComponent/EventComponent.jsx';
+import './LandingEventPreview.css';
+
+/**
+ * Public "taste of the product" preview shown on the landing page. Surfaces the
+ * soonest upcoming events from the public /events/upcoming feed so visitors can
+ * see real activity before creating an account.
+ */
+export default function LandingEventPreview({ limit = 6 }) {
+  const { events, loading, error } = useUpcomingEvents();
+
+  const soonest = [...events]
+    .sort((a, b) => new Date(a.eventStart) - new Date(b.eventStart))
+    .slice(0, limit);
+
+  return (
+    <section className="lep-section" aria-labelledby="lep-heading">
+      <div className="lep-header">
+        <h2 id="lep-heading">Happening soon near Cal Poly</h2>
+        <p>Real events on Findr right now — take a look before you sign up.</p>
+      </div>
+
+      {loading ? (
+        <div className="lep-grid" aria-hidden="true">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="lep-skeleton" />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="lep-empty">
+          Couldn’t load events right now — please check back soon.
+        </p>
+      ) : soonest.length === 0 ? (
+        <p className="lep-empty">
+          No upcoming events yet. Sign up and be the first to host one!
+        </p>
+      ) : (
+        <div className="lep-grid">
+          {soonest.map((event) => (
+            <EventComponent
+              key={event.id}
+              eventId={event.id}
+              eventName={event.eventName}
+              eventDate={event.eventDate}
+              eventTime={event.eventTime}
+              eventAddress={event.eventAddress}
+              description={event.description}
+              attendees={event.attendees}
+              host={event.host}
+              interest={event.interests.join(', ')}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="lep-cta">
+        <Link to="/explore" className="lep-explore-btn">
+          Explore all events →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/Pages/Explore/Explore.css
+++ b/frontend/src/Pages/Explore/Explore.css
@@ -1,0 +1,115 @@
+.explore-page {
+  min-height: 100vh;
+}
+
+.explore-hero {
+  width: min(1200px, 92%);
+  margin: 0 auto;
+  padding: 2rem 0 1rem;
+}
+
+.explore-hero h1 {
+  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
+  margin: 0 0 0.4rem;
+}
+
+.explore-hero p {
+  color: #5f6b7a;
+  margin: 0;
+}
+
+.explore-body {
+  width: min(1200px, 92%);
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.explore-filters {
+  position: sticky;
+  top: 1rem;
+}
+
+.explore-toolbar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.explore-search {
+  flex: 1 1 260px;
+  padding: 0.7rem 1rem;
+  border: 1px solid #d4dae2;
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+
+.explore-search:focus {
+  outline: none;
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.15);
+}
+
+.explore-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #5f6b7a;
+  font-size: 0.9rem;
+}
+
+.explore-sort select {
+  padding: 0.55rem 0.6rem;
+  border: 1px solid #d4dae2;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.explore-count {
+  color: #5f6b7a;
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+
+.explore-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.explore-skeleton {
+  height: 230px;
+  border-radius: 14px;
+  background: linear-gradient(100deg, #eef1f5 30%, #f7f9fb 50%, #eef1f5 70%);
+  background-size: 200% 100%;
+  animation: explore-shimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes explore-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.explore-empty {
+  color: #5f6b7a;
+  padding: 2rem 0;
+}
+
+@media (max-width: 860px) {
+  .explore-body {
+    grid-template-columns: 1fr;
+  }
+  .explore-filters {
+    position: static;
+  }
+}

--- a/frontend/src/Pages/Explore/Explore.jsx
+++ b/frontend/src/Pages/Explore/Explore.jsx
@@ -1,0 +1,168 @@
+import { useState, useMemo, useEffect } from 'react';
+import Navbar from '../../Components/Navbar/Navbar.jsx';
+import EventComponent from '../../Components/EventComponent/EventComponent.jsx';
+import SearchBar from '../../Components/SearchBar/SearchBar.jsx';
+import { useUpcomingEvents } from '../../Hooks/UseEvents.jsx';
+import { useAuth } from '../../Hooks/UseAuth';
+import './Explore.css';
+
+const attendeeCount = (e) => e.attendees?.length || 0;
+
+export default function ExplorePage() {
+  const { events, loading, error } = useUpcomingEvents();
+  const { user, isAuthenticated } = useAuth();
+
+  const [selectedInterests, setSelectedInterests] = useState([]);
+  const [dateRange, setDateRange] = useState({ startDate: '', endDate: '' });
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState('soonest');
+  const [myInterests, setMyInterests] = useState([]);
+
+  // Pull the signed-in user's interests to power the "For you" ranking.
+  useEffect(() => {
+    if (!isAuthenticated || !user?.token) {
+      setMyInterests([]);
+      return;
+    }
+    let active = true;
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${user.token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (active && json?.success && Array.isArray(json.data?.interests)) {
+          setMyInterests(json.data.interests);
+          setSort('foryou');
+        }
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [isAuthenticated, user?.token]);
+
+  const overlap = (eventInterests) =>
+    eventInterests.filter((i) => myInterests.includes(i)).length;
+
+  const filtered = useMemo(() => {
+    let list = [...events];
+
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      list = list.filter(
+        (e) =>
+          e.eventName.toLowerCase().includes(q) ||
+          (e.description || '').toLowerCase().includes(q)
+      );
+    }
+    if (selectedInterests.length) {
+      list = list.filter((e) =>
+        e.interests.some((i) => selectedInterests.includes(i))
+      );
+    }
+    if (dateRange.startDate) {
+      const s = new Date(dateRange.startDate);
+      list = list.filter((e) => new Date(e.eventStart) >= s);
+    }
+    if (dateRange.endDate) {
+      const en = new Date(dateRange.endDate);
+      en.setHours(23, 59, 59, 999);
+      list = list.filter((e) => new Date(e.eventStart) <= en);
+    }
+
+    list.sort((a, b) => {
+      if (sort === 'popular') return attendeeCount(b) - attendeeCount(a);
+      if (sort === 'foryou' && myInterests.length) {
+        const diff = overlap(b.interests) - overlap(a.interests);
+        if (diff !== 0) return diff;
+      }
+      return new Date(a.eventStart) - new Date(b.eventStart); // soonest
+    });
+
+    return list;
+  }, [events, query, selectedInterests, dateRange, sort, myInterests]);
+
+  return (
+    <div className="explore-page">
+      <Navbar page="/explore" />
+
+      <header className="explore-hero">
+        <h1>Explore events</h1>
+        <p>
+          Browse what’s happening around Cal Poly. Filter by interest, date, or
+          keyword{isAuthenticated ? ' — sorted for you.' : '.'}
+        </p>
+      </header>
+
+      <div className="explore-body">
+        <aside className="explore-filters">
+          <SearchBar
+            onSelectionChange={setSelectedInterests}
+            onDateChange={setDateRange}
+          />
+        </aside>
+
+        <main className="explore-results">
+          <div className="explore-toolbar">
+            <input
+              type="search"
+              className="explore-search"
+              placeholder="Search events by name or description…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search events"
+            />
+            <label className="explore-sort">
+              Sort:
+              <select value={sort} onChange={(e) => setSort(e.target.value)}>
+                {isAuthenticated && myInterests.length > 0 && (
+                  <option value="foryou">For you</option>
+                )}
+                <option value="soonest">Soonest</option>
+                <option value="popular">Most popular</option>
+              </select>
+            </label>
+          </div>
+
+          {loading ? (
+            <div className="explore-grid" aria-hidden="true">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="explore-skeleton" />
+              ))}
+            </div>
+          ) : error ? (
+            <p className="explore-empty">
+              Couldn’t load events right now — please try again later.
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="explore-empty">
+              No events match your filters. Try clearing some filters.
+            </p>
+          ) : (
+            <>
+              <p className="explore-count">
+                {filtered.length} event{filtered.length === 1 ? '' : 's'}
+              </p>
+              <div className="explore-grid">
+                {filtered.map((event) => (
+                  <EventComponent
+                    key={event.id}
+                    eventId={event.id}
+                    eventName={event.eventName}
+                    eventDate={event.eventDate}
+                    eventTime={event.eventTime}
+                    eventAddress={event.eventAddress}
+                    description={event.description}
+                    attendees={event.attendees}
+                    host={event.host}
+                    interest={event.interests.join(', ')}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Pages/Landing/Landing.jsx
+++ b/frontend/src/Pages/Landing/Landing.jsx
@@ -5,10 +5,11 @@ import community from '../../assets/community.svg';
 import LEBRON from '../../assets/LEBRON.mp4';
 import { useAuth } from '../../Hooks/UseAuth';
 import { useModal } from '../../Components/ModalContext.jsx';
+import LandingEventPreview from '../../Components/LandingEventPreview/LandingEventPreview.jsx';
 
 export default function LandingPage() {
   const { isAuthenticated } = useAuth();
-  const { openSignIn } = useModal();
+  const { openSignIn, openRegister } = useModal();
 
   return (
     <div className="landing-page">
@@ -36,6 +37,9 @@ export default function LandingPage() {
           </div>
         </section>
 
+        {/* Live, public taste of the product — real upcoming events. */}
+        <LandingEventPreview />
+
         <section className="feature-section connect-section">
           <div className="feature-content">
             <section className="features">
@@ -56,8 +60,8 @@ export default function LandingPage() {
               <div className="feature">
                 <h2>Safety & Verification</h2>
                 <p>
-                  You can definitely, totally trust us with your safety and
-                  data.
+                  Cal Poly students can verify with their school email, and you
+                  control who sees your profile and events.
                 </p>
               </div>
             </section>
@@ -124,12 +128,20 @@ export default function LandingPage() {
 
         <section className="newsletter-section">
           <div className="newsletter-content">
-            <h2>Get the latest updates</h2>
-            <p>Sign up to receive top stories and tips from Findr.</p>
-            <form className="newsletter-form">
-              <input type="email" placeholder="Enter your email" />
-              <button type="submit">Subscribe</button>
-            </form>
+            <h2>Ready to find your people?</h2>
+            <p>
+              Join Findr to RSVP, host your own events, and connect with your
+              community.
+            </p>
+            {!isAuthenticated ? (
+              <button className="cta-button" onClick={openRegister}>
+                Create your account
+              </button>
+            ) : (
+              <Link to="/explore" className="cta-button">
+                Explore events
+              </Link>
+            )}
           </div>
         </section>
       </main>
@@ -138,10 +150,9 @@ export default function LandingPage() {
         <div className="footer-content">
           <p>&copy; 2026 Findr. All rights reserved.</p>
           <div className="footer-links">
-            <a href="/privacy">Privacy</a>
-            <a href="/terms">Terms</a>
-            <a href="/help">Help</a>
-            <a href="/business">Business</a>
+            <Link to="/explore">Explore</Link>
+            <Link to="/about">About</Link>
+            <a href="mailto:hello@findr.page">Contact</a>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## What & why
Gives visitors a **taste of the product before signing up**, and adds a richer no-map browsing surface.

### Landing page
- **`LandingEventPreview`** — a public grid of the soonest upcoming events (from the public `/events/upcoming` feed). Visitors see real activity with **no account**; cards gate actions behind a "Sign in to join" prompt.
- Replaced the placeholder "you can totally trust us" safety copy with real copy.
- Replaced the **dead newsletter form** with a real "Create your account" CTA.
- Fixed **dead footer links** (`/privacy /terms /help /business` all 404'd) → Explore / About / Contact.

### Explore page (`/explore`, public)
- Filterable recommended-events list, **no map**. Reuses `SearchBar` (interests + date) plus a keyword search and a sort control: **Soonest / Most popular / For you**.
- **"For you"** pulls the signed-in user's interests from `GET /users/me` and ranks by interest overlap (defaults to it when you're logged in and have interests).
- Responsive — the filter sidebar collapses on mobile.

## Verification
- ✅ Frontend unit suite green (163 passing).
- ✅ `npm run build` (frontend) succeeds.
- ✅ No eslint errors (only the repo's pre-existing unused-import warnings).

## Notes / follow-ups
- Event cards still link to `/events/:id` only when logged in (that route is auth-gated). Making event detail publicly viewable (with auth-gated RSVP/comments) is a natural Phase 4 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)