### PR TITLE
Feature D: unify Google OAuth to issue the same JWT as standard auth

### DIFF
--- a/backend/OAuth/GoogleAuthRoutes.js
+++ b/backend/OAuth/GoogleAuthRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import passport from 'passport';
+import jwt from 'jsonwebtoken';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { config } from 'dotenv';
 import path from 'path';
@@ -79,11 +80,37 @@ router.get(
   '/google/callback',
   passport.authenticate('google', { failureRedirect: '/' }),
   (req, res) => {
-    const redirectUrl =
+    // Issue the SAME tokens as standard email/password auth so the whole
+    // app runs on one JWT model (no longer relying on the passport session
+    // for app auth).
+    const userId = req.user._id;
+
+    const accessToken = jwt.sign({ id: userId }, process.env.JWT_TOKEN_SECRET, {
+      expiresIn: '15m',
+    });
+
+    const refreshToken = jwt.sign(
+      { id: userId },
+      process.env.REFRESH_TOKEN_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    // Set refresh token as HttpOnly cookie (identical options to /users/login)
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+
+    // Redirect to the SPA carrying the access token in the URL hash so the
+    // frontend can store it and populate auth state.
+    const frontendBase =
       process.env.NODE_ENV === 'production'
         ? process.env.FRONTEND_URL
         : 'http://localhost:5173';
-    res.redirect(redirectUrl);
+
+    res.redirect(`${frontendBase}/#token=${accessToken}&userId=${userId}`);
   }
 );
 

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.css
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.css
@@ -165,6 +165,57 @@
   cursor: not-allowed;
 }
 
+.modal__divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.25rem 0;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.modal__divider::before,
+.modal__divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.modal__google {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  background: #fff;
+  color: #1f1f1f;
+  border: none;
+  border-radius: 8px;
+  padding: 0.7rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
+}
+
+.modal__google:hover {
+  background: #f1f1f1;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.modal__google-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
 .modal__footer {
   margin: 1.25rem 0 0;
   text-align: center;

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
@@ -8,7 +8,7 @@ export default function SignInModal({ isOpen, onClose, onSwitchToRegister }) {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
-  const { login } = useAuth();
+  const { login, loginWithGoogle } = useAuth();
   const navigate = useNavigate();
 
   // Close on Escape key
@@ -88,6 +88,38 @@ export default function SignInModal({ isOpen, onClose, onSwitchToRegister }) {
             {loading ? 'Signing in...' : 'Sign In'}
           </button>
         </form>
+
+        <div className="modal__divider">
+          <span>or</span>
+        </div>
+
+        <button
+          type="button"
+          className="modal__google"
+          onClick={loginWithGoogle}>
+          <svg
+            className="modal__google-icon"
+            viewBox="0 0 18 18"
+            aria-hidden="true">
+            <path
+              fill="#4285F4"
+              d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+            />
+            <path
+              fill="#34A853"
+              d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332z"
+            />
+            <path
+              fill="#EA4335"
+              d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.167 6.656 3.58 9 3.58z"
+            />
+          </svg>
+          Continue with Google
+        </button>
 
         <p className="modal__footer">
           Don't have an account?{' '}

--- a/frontend/src/Hooks/UseAuth.ts
+++ b/frontend/src/Hooks/UseAuth.ts
@@ -60,10 +60,51 @@ export const useProvideAuth = () => {
     }
   };
 
-  // Check session using refresh token (HttpOnly cookie)
+  // ── Helper: consume an access token handed back via the URL hash ──
+  // Google OAuth redirects to `/#token=<jwt>&userId=<id>`. When present we
+  // adopt that token (same JWT model as email/password login), fetch the
+  // user profile, clean the hash, and land on /home.
+  const consumeHashToken = async (): Promise<boolean> => {
+    const hash = window.location.hash;
+    if (!hash || !hash.includes('token=')) return false;
+
+    const params = new URLSearchParams(hash.replace(/^#/, ''));
+    const token = params.get('token');
+    const userId = params.get('userId');
+    if (!token || !userId) return false;
+
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/users/me`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      const profile: Partial<UserState> = res.ok
+        ? await res
+            .json()
+            .then((json) => ({
+              name: json.data?.name || '',
+              avatar: json.data?.avatar || null,
+            }))
+            .catch(() => ({}))
+        : {};
+      setUser({ id: userId, token, ...profile });
+    } catch {
+      setUser({ id: userId, token });
+    }
+
+    // Strip the token from the URL so it isn't left in history/bookmarks.
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+    navigate('/home');
+    return true;
+  };
+
+  // Check session: first try a Google OAuth hash token, then fall back to the
+  // refresh token (HttpOnly cookie).
   useEffect(() => {
     const checkSession = async () => {
       try {
+        if (await consumeHashToken()) return;
+
         const res = await fetch(
           `${import.meta.env.VITE_API_BASE_URL}/users/refresh-token`,
           { method: 'POST', credentials: 'include' }
@@ -84,7 +125,13 @@ export const useProvideAuth = () => {
     };
 
     checkSession();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // ── Redirect the browser to start the Google OAuth flow ──
+  const loginWithGoogle = () => {
+    window.location.href = `${import.meta.env.VITE_API_BASE_URL}/auth/google`;
+  };
 
   const login = async (email: string, password: string) => {
     const res = await fetch(
@@ -171,6 +218,7 @@ export const useProvideAuth = () => {
   return {
     user,
     login,
+    loginWithGoogle,
     register,
     logout,
     updateProfileImage,


### PR DESCRIPTION
## Summary
Unifies Google OAuth with standard email/password auth so the whole app runs on a single JWT model. Google login no longer depends on the passport session for app auth.

### Backend (`backend/OAuth/GoogleAuthRoutes.js`)
- `GET /auth/google/callback` now, after passport resolves/creates the user, signs:
  - an **access token** (`{ id }`, `JWT_TOKEN_SECRET`, `expiresIn: 15m`)
  - a **refresh token** (`{ id }`, `REFRESH_TOKEN_SECRET`, `expiresIn: 7d`)
  - exactly like `UserRoutes` `/login`.
- Sets the `refreshToken` HttpOnly cookie with identical options (`httpOnly`; `secure` in prod; `sameSite` `none` in prod else `lax`; `maxAge` 7d).
- Redirects the browser to the SPA carrying the access token in the URL hash: prod `${FRONTEND_URL}/#token=<accessToken>&userId=<id>`, dev `http://localhost:5173/#token=...`.
- Passport google strategy + handshake + serialize/deserialize left in place.

### Frontend
- `Hooks/UseAuth.ts`: the mount/session-check effect now first consumes a `token` from `window.location.hash` if present — stores the token, fetches `/users/me` with `Authorization: Bearer <token>` to populate the user, cleans the hash via `history.replaceState`, and navigates to `/home`. Falls back to the existing refresh-token cookie flow otherwise. Adds `loginWithGoogle()` which sets `window.location.href = ${VITE_API_BASE_URL}/auth/google`. (No `/auth/callback` route or `App.jsx` change needed.)
- `Components/Modals/SignInModal/SignInModal.jsx` (+`.css`): adds a "Continue with Google" button that calls `loginWithGoogle()`, with a divider and styling.

No new backend or frontend dependencies (`jsonwebtoken` already a backend dep).

## How tested
- `node --check backend/OAuth/GoogleAuthRoutes.js` — OK
- `npx jest --config=jest.config.cjs --selectProjects unit-frontend` — GREEN (19 suites, 163 passed)
- `npm run build --prefix frontend` — succeeds (TS compiles clean)
- `npx eslint` on changed JSX — zero errors
- GoogleAuth integration test unchanged and still asserts the failure-path redirect (only the success handler changed); full Jest suite incl. integration runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)