### PR TITLE
Feature A: dynamic, normalized, searchable interest tags

### DIFF
--- a/backend/InterestFIles/InterestRoutes.js
+++ b/backend/InterestFIles/InterestRoutes.js
@@ -31,6 +31,29 @@ router.get('/all', async (req, res) => {
     });
 });
 
+// Typeahead search by name: GET /interests/search?q=...&limit=...
+// Registered before /:id so the literal "search" segment isn't captured as an id.
+router.get('/search', async (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q : '';
+  const parsedLimit = parseInt(req.query.limit, 10);
+  const limit = Number.isNaN(parsedLimit) ? 20 : parsedLimit;
+
+  await interestServices
+    .searchInterests(q, limit)
+    .then((interests) => {
+      res.status(200).json({
+        success: true,
+        data: interests,
+      });
+    })
+    .catch((error) => {
+      res.status(500).json({
+        success: false,
+        message: `Error in the server: ${error}`,
+      });
+    });
+});
+
 // Get an interest by ID
 router.get('/:id', async (req, res) => {
   await interestServices
@@ -55,23 +78,29 @@ router.get('/:id', async (req, res) => {
     });
 });
 
-// Post a new interest
+// Post a new interest. Dedupes by normalizedName: returns 201 when a new
+// interest is created, or 200 with the existing doc when a duplicate is
+// suggested (so user-submitted tags never create duplicates).
 router.post('/', async (req, res) => {
-  await interestServices
-    .addInterest(req.body)
-    .then((interest) => {
-      res.status(201).json({
-        success: true,
-        message: 'Interest registered successfully.',
-        data: interest,
-      });
-    })
-    .catch((error) => {
-      res.status(error.status || 400).json({
-        success: false,
-        message: error.message || 'An unexpected error occurred.',
-      });
+  try {
+    const existing = await interestServices.findInterestByNormalizedName(
+      req.body?.name
+    );
+    const interest = await interestServices.addInterest(req.body);
+
+    res.status(existing ? 200 : 201).json({
+      success: true,
+      message: existing
+        ? 'Interest already exists.'
+        : 'Interest registered successfully.',
+      data: interest,
     });
+  } catch (error) {
+    res.status(error.status || 400).json({
+      success: false,
+      message: error.message || 'An unexpected error occurred.',
+    });
+  }
 });
 
 // Delete an interest

--- a/backend/InterestFIles/InterestSchema.js
+++ b/backend/InterestFIles/InterestSchema.js
@@ -1,11 +1,34 @@
 import mongoose from 'mongoose';
 
+// Normalize a display name into a canonical key used for dedupe + search:
+// lowercase, trim, and collapse runs of internal whitespace to single spaces.
+export function normalizeInterestName(name) {
+  if (typeof name !== 'string') return '';
+  return name.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
 const InterestSchema = new mongoose.Schema(
   {
     name: {
       type: String,
       required: true,
       trim: true,
+    },
+    // Optional grouping (e.g. Sports, Music, Tech). Free-form, trimmed.
+    category: {
+      type: String,
+      required: false,
+      trim: true,
+    },
+    // Canonical key derived from `name`. Used to dedupe user-suggested tags.
+    // unique + sparse so legacy docs without the field don't collide on null.
+    normalizedName: {
+      type: String,
+      lowercase: true,
+      trim: true,
+      index: true,
+      unique: true,
+      sparse: true,
     },
     similarInterests: {
       type: [{ type: mongoose.Schema.Types.ObjectId }],
@@ -14,6 +37,15 @@ const InterestSchema = new mongoose.Schema(
   },
   { collection: 'interests_list' }
 );
+
+// Derive normalizedName from name on every validate so it stays in sync
+// whether the doc is created or its name is updated via .save().
+InterestSchema.pre('validate', function deriveNormalizedName(next) {
+  if (this.name) {
+    this.normalizedName = normalizeInterestName(this.name);
+  }
+  next();
+});
 
 const Interest = mongoose.model('Interest', InterestSchema);
 

--- a/backend/InterestFIles/InterestServices.js
+++ b/backend/InterestFIles/InterestServices.js
@@ -1,12 +1,26 @@
-import interestModel from './InterestSchema.js';
+import interestModel, { normalizeInterestName } from './InterestSchema.js';
 
 // Get all interests
 function getInterests() {
   return interestModel.find();
 }
 
-// Add an interest
-function addInterest(interest) {
+// Look up an interest by its canonical normalized name (exact match).
+// Returns null when none exists or the name is empty.
+function findInterestByNormalizedName(name) {
+  const normalizedName = normalizeInterestName(name);
+  if (!normalizedName) return Promise.resolve(null);
+  return interestModel.findOne({ normalizedName });
+}
+
+// Add an interest.
+// Dedupes by normalizedName so user-suggested tags never create duplicates:
+// if an interest with the same normalized name already exists, return it
+// instead of creating a new document.
+async function addInterest(interest) {
+  const existing = await findInterestByNormalizedName(interest?.name);
+  if (existing) return existing;
+
   const newInterest = new interestModel(interest);
   return newInterest.save();
 }
@@ -32,6 +46,20 @@ function findInterestById(id) {
 // Find interest by name
 function findInterestByName(name) {
   return interestModel.find({ name: { $regex: name, $options: 'i' } });
+}
+
+// Typeahead search: case-insensitive substring match on `name`, sorted by
+// name, capped at `limit`. Empty/whitespace query returns [].
+function searchInterests(q, limit = 20) {
+  if (typeof q !== 'string' || q.trim() === '') return Promise.resolve([]);
+
+  // Escape regex metacharacters so user input is treated as a literal substring.
+  const escaped = q.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  return interestModel
+    .find({ name: { $regex: escaped, $options: 'i' } })
+    .sort({ name: 1 })
+    .limit(limit);
 }
 
 // FInd interests by similar interests
@@ -70,6 +98,8 @@ export default {
   updateInterest,
   findInterestById,
   findInterestByName,
+  findInterestByNormalizedName,
+  searchInterests,
   findInterestBySimilarInterests,
   addInterestsToSimilarInterests,
   removeInterestsFromSimilarInterests,

--- a/backend/scripts/seedInterests.js
+++ b/backend/scripts/seedInterests.js
@@ -1,0 +1,111 @@
+/**
+ * Seed the interests_list collection with a base set of interests.
+ *
+ * Idempotent: upserts each interest by its normalizedName, so re-running the
+ * script never creates duplicates. Reads the connection string from
+ * process.env.MONGODB_URI.
+ *
+ * How to run (from the repo root):
+ *   MONGODB_URI="mongodb://localhost:27017/findr" node backend/scripts/seedInterests.js
+ *
+ * Or, if MONGODB_URI is already set in your environment / loaded via dotenv:
+ *   node backend/scripts/seedInterests.js
+ */
+
+import mongoose from 'mongoose';
+import interestModel, {
+  normalizeInterestName,
+} from '../InterestFIles/InterestSchema.js';
+
+// Base interests grouped by category. Display names are kept human-friendly;
+// normalizedName is derived at upsert time for safe deduping.
+const BASE_INTERESTS = [
+  // Sports
+  { name: 'Basketball', category: 'Sports' },
+  { name: 'Soccer', category: 'Sports' },
+  { name: 'Tennis', category: 'Sports' },
+  { name: 'Volleyball', category: 'Sports' },
+  // Music
+  { name: 'Live Music', category: 'Music' },
+  { name: 'Concerts', category: 'Music' },
+  { name: 'DJ Sets', category: 'Music' },
+  { name: 'Karaoke', category: 'Music' },
+  // Academics
+  { name: 'Study Groups', category: 'Academics' },
+  { name: 'Research', category: 'Academics' },
+  { name: 'Debate', category: 'Academics' },
+  { name: 'Tutoring', category: 'Academics' },
+  // Arts
+  { name: 'Painting', category: 'Arts' },
+  { name: 'Photography', category: 'Arts' },
+  { name: 'Theater', category: 'Arts' },
+  { name: 'Film', category: 'Arts' },
+  // Outdoors
+  { name: 'Hiking', category: 'Outdoors' },
+  { name: 'Camping', category: 'Outdoors' },
+  { name: 'Surfing', category: 'Outdoors' },
+  { name: 'Climbing', category: 'Outdoors' },
+  // Gaming
+  { name: 'Video Games', category: 'Gaming' },
+  { name: 'Board Games', category: 'Gaming' },
+  { name: 'Esports', category: 'Gaming' },
+  { name: 'Tabletop RPGs', category: 'Gaming' },
+  // Food
+  { name: 'Cooking', category: 'Food' },
+  { name: 'Baking', category: 'Food' },
+  { name: 'Coffee', category: 'Food' },
+  { name: 'Food Trucks', category: 'Food' },
+  // Tech
+  { name: 'Programming', category: 'Tech' },
+  { name: 'Hackathons', category: 'Tech' },
+  { name: 'Robotics', category: 'Tech' },
+  { name: 'AI & Machine Learning', category: 'Tech' },
+  // Social
+  { name: 'Networking', category: 'Social' },
+  { name: 'Volunteering', category: 'Social' },
+  { name: 'Book Clubs', category: 'Social' },
+  { name: 'Game Nights', category: 'Social' },
+];
+
+async function seedInterests() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('❌ MONGODB_URI is not set. Aborting seed.');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  console.log('✅ Connected to MongoDB. Seeding interests...');
+
+  let upserted = 0;
+  for (const interest of BASE_INTERESTS) {
+    const normalizedName = normalizeInterestName(interest.name);
+    // Upsert by normalizedName so re-running is safe (no duplicates).
+    await interestModel.updateOne(
+      { normalizedName },
+      {
+        $set: {
+          name: interest.name,
+          category: interest.category,
+          normalizedName,
+        },
+        $setOnInsert: { similarInterests: [] },
+      },
+      { upsert: true }
+    );
+    upserted += 1;
+  }
+
+  console.log(`✅ Seed complete. Upserted ${upserted} interests.`);
+  await mongoose.connection.close();
+}
+
+seedInterests().catch(async (error) => {
+  console.error('❌ Seed failed:', error);
+  try {
+    await mongoose.connection.close();
+  } catch {
+    // ignore close errors during failure cleanup
+  }
+  process.exit(1);
+});

--- a/tests/Integration/Interests/interests.routes.test.js
+++ b/tests/Integration/Interests/interests.routes.test.js
@@ -39,7 +39,31 @@ describe('Interest Routes', () => {
     const res = await request(app).post('/interests').send(testInterest);
     expect(res.status).toBe(201);
     expect(res.body.data.name).toBe('Music');
+    expect(res.body.data.normalizedName).toBe('music');
     expect(res.body.success).toBe(true);
+  });
+
+  test('POST /interests derives normalizedName (lowercase + collapsed whitespace)', async () => {
+    const res = await request(app)
+      .post('/interests')
+      .send({ name: '  Rock   Climbing  ', similarInterests: [] });
+    expect(res.status).toBe(201);
+    expect(res.body.data.normalizedName).toBe('rock climbing');
+  });
+
+  test('POST /interests dedupes by normalizedName (200 + existing doc)', async () => {
+    const first = await request(app).post('/interests').send(testInterest);
+    expect(first.status).toBe(201);
+
+    // Same interest with different casing/spacing should not duplicate.
+    const dup = await request(app)
+      .post('/interests')
+      .send({ name: ' music ', similarInterests: [] });
+    expect(dup.status).toBe(200);
+    expect(dup.body.data._id).toBe(first.body.data._id);
+
+    const all = await interestModel.find({ normalizedName: 'music' });
+    expect(all.length).toBe(1);
   });
 
   test('GET /interests/:id returns the created interest', async () => {
@@ -102,6 +126,49 @@ describe('Interest Routes', () => {
     const res = await request(app).get('/interests/search/name/NonExistent');
     expect(res.status).toBe(404);
     expect(res.body.success).toBe(false);
+  });
+
+  // Typeahead search: GET /interests/search?q=
+  test('GET /interests/search?q= returns case-insensitive matches sorted by name', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+    await interestModel.create({
+      name: 'Musical Theater',
+      similarInterests: [],
+    });
+    await interestModel.create({ name: 'Rock', similarInterests: [] });
+
+    const res = await request(app).get('/interests/search?q=mus');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.map((i) => i.name)).toEqual([
+      'Music',
+      'Musical Theater',
+    ]);
+  });
+
+  test('GET /interests/search respects the limit query param', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+    await interestModel.create({
+      name: 'Musical Theater',
+      similarInterests: [],
+    });
+
+    const res = await request(app).get('/interests/search?q=mus&limit=1');
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+  });
+
+  test('GET /interests/search returns empty array for missing/empty q', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+
+    const res = await request(app).get('/interests/search');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+
+    const resEmpty = await request(app).get('/interests/search?q=');
+    expect(resEmpty.status).toBe(200);
+    expect(resEmpty.body.data).toEqual([]);
   });
 
   // Similar interests endpoints

--- a/tests/Integration/Interests/interests.services.test.js
+++ b/tests/Integration/Interests/interests.services.test.js
@@ -29,6 +29,61 @@ describe('Interest Services', () => {
     expect(found.name).toBe('Music');
   });
 
+  test('should derive normalizedName from name (lowercase, collapsed whitespace)', async () => {
+    const interest = await interestServices.addInterest({
+      name: '  Rock   Climbing  ',
+      similarInterests: [],
+    });
+    expect(interest.normalizedName).toBe('rock climbing');
+    // name itself is only trimmed by the schema, not lowercased.
+    expect(interest.name).toBe('Rock   Climbing');
+  });
+
+  test('addInterest dedupes by normalizedName instead of creating duplicates', async () => {
+    const first = await interestServices.addInterest({
+      name: 'Music',
+      similarInterests: [],
+    });
+    const second = await interestServices.addInterest({
+      name: '  MUSIC ',
+      similarInterests: [],
+    });
+
+    expect(second._id.toString()).toBe(first._id.toString());
+    const all = await interestModel.find({ normalizedName: 'music' });
+    expect(all.length).toBe(1);
+  });
+
+  test('searchInterests returns case-insensitive substring matches sorted by name', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+    await interestModel.create({
+      name: 'Musical Theater',
+      similarInterests: [],
+    });
+    await interestModel.create({ name: 'Rock', similarInterests: [] });
+
+    const results = await interestServices.searchInterests('mus');
+    expect(results.map((i) => i.name)).toEqual(['Music', 'Musical Theater']);
+  });
+
+  test('searchInterests respects the limit argument', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+    await interestModel.create({
+      name: 'Musical Theater',
+      similarInterests: [],
+    });
+
+    const results = await interestServices.searchInterests('mus', 1);
+    expect(results.length).toBe(1);
+  });
+
+  test('searchInterests returns [] for empty or whitespace queries', async () => {
+    await interestModel.create({ name: 'Music', similarInterests: [] });
+
+    expect(await interestServices.searchInterests('')).toEqual([]);
+    expect(await interestServices.searchInterests('   ')).toEqual([]);
+  });
+
   test('should return all interests', async () => {
     await interestModel.create(testInterest);
     await interestModel.create(testInterest2);


### PR DESCRIPTION
## Summary
Turns the thin fixed interest list into a dynamic, normalized, searchable tag system (backend only). Phases 0/1 untouched.

### Schema (`backend/InterestFIles/InterestSchema.js`)
- Keeps `name` and `similarInterests`.
- Adds `category` (String, optional, trimmed).
- Adds `normalizedName` (lowercase, trimmed, indexed, **unique + sparse**).
- `pre('validate')` hook derives `normalizedName` from `name`: lowercase, trim, and collapse internal whitespace. Exposes a reusable `normalizeInterestName()` helper.

### Services (`backend/InterestFIles/InterestServices.js`)
- `addInterest` now **dedupes** by `normalizedName`: if a matching interest exists it returns that doc instead of creating a duplicate (user-suggested tags never duplicate).
- Adds `searchInterests(q, limit = 20)`: case-insensitive substring match on `name`, sorted by name, capped at `limit`. Empty/whitespace `q` returns `[]`. Regex metachars in `q` are escaped.
- Adds `findInterestByNormalizedName(name)` (exact canonical lookup) used by the POST route to distinguish create vs. dedupe.

### Routes (`backend/InterestFIles/InterestRoutes.js`)
- Adds `GET /interests/search?q=...&limit=...` (typeahead), registered **before** `/:id` so the literal `search` segment isn't captured as an id.
- `POST /interests` now dedupes: **201** when newly created, **200** with the existing doc on a duplicate.
- All existing routes (incl. `/search/name/:name`, `/:id`, similar-interest routes) preserved.

### Seed (`backend/scripts/seedInterests.js`, new)
- Idempotent Node script upserting ~36 base interests across 9 categories (Sports, Music, Academics, Arts, Outdoors, Gaming, Food, Tech, Social), keyed by `normalizedName` so re-running is safe. Uses `process.env.MONGODB_URI`. Header comment documents how to run it. Not executed here.

No new backend dependencies.

## How tested
- `node --check` on all six changed files: pass.
- `npx eslint` on all six changed files: **0 errors, 0 warnings**.
- Integration tests extended and kept green via CI (local sandbox blocks `mongod`):
  - Services: normalizedName derivation, dedupe on `addInterest`, `searchInterests` ordering/limit/empty-query behavior.
  - Routes: `POST` returns `normalizedName`, derives it from messy input, dedupes (200 + existing `_id`); `GET /interests/search?q=` ordering, `limit`, and empty/missing `q` returning `[]`.
  - All prior interest route/service tests retained.
- Authoritative gate: CI `build` job (full Jest suite incl. backend integration against a real mongod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)