### PR TITLE
Phase 2 (B): interest typeahead + user-suggested tags in onboarding

### DIFF
--- a/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
+++ b/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
@@ -362,3 +362,9 @@
   border-color: #f87171;
   box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.15);
 }
+
+/* "Add new interest" option in the interests dropdown */
+.rmodal__dropdown li.rmodal__create-option {
+  color: #1f6feb;
+  font-weight: 600;
+}

--- a/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.jsx
+++ b/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.jsx
@@ -74,7 +74,14 @@ export default function RegistrationModal({
   onClose,
   onSwitchToSignIn,
 }) {
-  const { interests, loading: interestsLoading } = useInterests();
+  const {
+    interests,
+    loading: interestsLoading,
+    searchInterests,
+    createInterest,
+  } = useInterests();
+  const [searchResults, setSearchResults] = useState([]);
+  const [creatingInterest, setCreatingInterest] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
@@ -138,6 +145,23 @@ export default function RegistrationModal({
     setDropdownOpen((o) => !o);
   }, [interestsLoading, dropdownOpen]);
 
+  // Debounced server-side typeahead so users can find interests beyond the
+  // initially loaded list. (Hook must stay above the early return below.)
+  React.useEffect(() => {
+    const q = interestSearch.trim();
+    if (!q) {
+      // Keep the same array reference when already empty so this effect can't
+      // trigger a re-render loop (searchInterests identity may change).
+      setSearchResults((prev) => (prev.length ? [] : prev));
+      return;
+    }
+    const t = setTimeout(async () => {
+      const results = await searchInterests(q);
+      setSearchResults(results);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [interestSearch, searchInterests]);
+
   if (!isOpen) return null;
 
   const toggleInterest = (interest) => {
@@ -152,9 +176,32 @@ export default function RegistrationModal({
     setSelectedInterests((prev) => prev.filter((i) => i !== interest));
   };
 
-  const filteredInterests = interests.filter((i) =>
-    i.name.toLowerCase().includes(interestSearch.toLowerCase())
+  // Show search results when searching, else the loaded base list.
+  const displayedInterests = interestSearch.trim() ? searchResults : interests;
+  const trimmedSearch = interestSearch.trim();
+  const hasExactMatch = displayedInterests.some(
+    (i) => i.name.toLowerCase() === trimmedSearch.toLowerCase()
   );
+
+  // Create (or dedupe to) a user-suggested interest and select it.
+  const handleCreateInterest = async () => {
+    const name = trimmedSearch;
+    if (!name || creatingInterest) return;
+    setCreatingInterest(true);
+    try {
+      const created = await createInterest(name);
+      const interestName = created?.name || name;
+      setSelectedInterests((prev) =>
+        prev.includes(interestName) ? prev : [...prev, interestName]
+      );
+      setInterestSearch('');
+      setSearchResults([]);
+    } catch {
+      // Silently ignore — the user can retry; not a blocker for signup.
+    } finally {
+      setCreatingInterest(false);
+    }
+  };
 
   // Clear individual field error on change
   const clearError = (field) => {
@@ -424,9 +471,9 @@ export default function RegistrationModal({
                     onClick={(e) => e.stopPropagation()}
                   />
                   <ul>
-                    {filteredInterests.map((interest) => (
+                    {displayedInterests.map((interest) => (
                       <li
-                        key={interest._id}
+                        key={interest._id || interest.name}
                         className={
                           selectedInterests.includes(interest.name)
                             ? 'selected'
@@ -439,6 +486,16 @@ export default function RegistrationModal({
                         {interest.name}
                       </li>
                     ))}
+                    {trimmedSearch && !hasExactMatch && (
+                      <li
+                        className="rmodal__create-option"
+                        onClick={handleCreateInterest}>
+                        <span className="rmodal__check">＋</span>
+                        {creatingInterest
+                          ? `Adding “${trimmedSearch}”…`
+                          : `Add “${trimmedSearch}”`}
+                      </li>
+                    )}
                   </ul>
                 </div>
               )}

--- a/frontend/src/Hooks/UseInterests.jsx
+++ b/frontend/src/Hooks/UseInterests.jsx
@@ -1,5 +1,5 @@
 // Hooks/useInterests.js
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 export default function useInterests() {
   const [interests, setInterests] = useState([]);
@@ -29,5 +29,36 @@ export default function useInterests() {
     fetchInterests();
   }, []);
 
-  return { interests, loading, error };
+  // Server-side typeahead — scales past the initially loaded list.
+  const searchInterests = useCallback(async (q) => {
+    if (!q || !q.trim()) return [];
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/interests/search?q=${encodeURIComponent(
+          q.trim()
+        )}`
+      );
+      if (!res.ok) return [];
+      const json = await res.json();
+      return json.success ? json.data : [];
+    } catch {
+      return [];
+    }
+  }, []);
+
+  // Create a user-suggested interest. The backend normalizes + dedupes, so this
+  // returns the existing interest if one already matches.
+  const createInterest = useCallback(async (name) => {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/interests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name.trim() }),
+    });
+    const json = await res.json();
+    if (!json.success)
+      throw new Error(json.message || 'Could not add interest');
+    return json.data;
+  }, []);
+
+  return { interests, loading, error, searchInterests, createInterest };
 }

--- a/tests/unit/frontend/RegistrationModal.test.jsx
+++ b/tests/unit/frontend/RegistrationModal.test.jsx
@@ -13,6 +13,8 @@ jest.mock('../../../frontend/src/Hooks/UseInterests.jsx', () => ({
     interests: [{ name: 'Music' }, { name: 'Tech' }],
     loading: false,
     error: null,
+    searchInterests: jest.fn().mockResolvedValue([]),
+    createInterest: jest.fn().mockResolvedValue({ name: 'New Interest' }),
   })),
 }));
 


### PR DESCRIPTION
## What & why
Wires the dynamic interest API (feature A, #123) into the registration interest picker so users aren't limited to a fixed list — they can search the full catalog as they type and suggest new tags.

## Changes
- **`UseInterests`**: `searchInterests(q)` (debounced server-side typeahead via `GET /interests/search`) and `createInterest(name)` (`POST /interests`, which normalizes + dedupes server-side).
- **`RegistrationModal`**: the interests dropdown searches the backend as you type and offers an **"Add '<query>'"** option to create a new (deduped) interest, which is then selected. Chosen interests already feed the curated Explore "For you" ranking.
- Guarded the empty-query branch of the debounce effect against a re-render loop (returns the same array reference when already empty — only surfaced under the test's per-render mock identity; real code uses a `useCallback`-stable fn).
- Updated the RegistrationModal test mock to expose the new hook functions.

## How tested
- Frontend unit suite green: **19 suites / 163 passing**.
- `npm run build --prefix frontend` succeeds.
- No eslint errors. CI runs the full suite as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)