### PR TITLE
Phase 2 (C): geocode city at signup + bounded "Near me" loading

### DIFF
--- a/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.jsx
+++ b/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.jsx
@@ -69,6 +69,33 @@ const validate = ({
   return errors;
 };
 
+// Best-effort city -> coordinates lookup (OpenStreetMap Nominatim). Returns
+// { latitude, longitude } or null; never throws so it can't block signup.
+async function geocodeCity(city) {
+  try {
+    const params = new URLSearchParams({
+      q: city,
+      format: 'json',
+      limit: '1',
+    });
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/search?${params}`,
+      { headers: { 'Accept-Language': 'en' } }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (Array.isArray(data) && data[0]?.lat && data[0]?.lon) {
+      return {
+        latitude: parseFloat(data[0].lat),
+        longitude: parseFloat(data[0].lon),
+      };
+    }
+  } catch {
+    // ignore — signup proceeds without a location
+  }
+  return null;
+}
+
 export default function RegistrationModal({
   isOpen,
   onClose,
@@ -233,6 +260,9 @@ export default function RegistrationModal({
 
     setErrors({});
     try {
+      // Geocode the city so the new user gets a location point for the
+      // location-bounded feed. Non-blocking: sign up proceeds even if it fails.
+      const location = await geocodeCity(city);
       await register({
         name,
         phoneNumber,
@@ -242,6 +272,7 @@ export default function RegistrationModal({
         email,
         password,
         interests: selectedInterests,
+        ...(location ? { location } : {}),
       });
       onClose();
       navigate('/home');

--- a/frontend/src/Hooks/UseEvents.jsx
+++ b/frontend/src/Hooks/UseEvents.jsx
@@ -64,6 +64,51 @@ export function useUpcomingEvents() {
   return { events, loading, error, refetch: fetchEvents };
 }
 
+// Bounded, location-aware feed: upcoming events within `radiusMeters` of a
+// point, using the indexed /events/nearby endpoint. Pass coords = null to stay
+// idle (e.g. until the user's location is known).
+export function useNearbyEvents(coords, radiusMeters = 16093) {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const lat = coords?.lat;
+  const lng = coords?.lng;
+
+  useEffect(() => {
+    if (lat == null || lng == null) {
+      setEvents([]);
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams({
+      lng: String(lng),
+      lat: String(lat),
+      radius: String(radiusMeters),
+    });
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/events/nearby?${params}`)
+      .then((res) => res.json())
+      .then((result) => {
+        if (!active) return;
+        if (result.success) setEvents(mapEvents(result.data));
+        else {
+          setEvents([]);
+          setError(result.message);
+        }
+      })
+      .catch((err) => active && setError(err.message))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [lat, lng, radiusMeters]);
+
+  return { events, loading, error };
+}
+
 export function useEventId(id) {
   const [event, setEvent] = useState();
   const [loading, setLoading] = useState(true);

--- a/frontend/src/Pages/Explore/Explore.css
+++ b/frontend/src/Pages/Explore/Explore.css
@@ -70,6 +70,35 @@
   background: #fff;
 }
 
+.explore-nearme {
+  padding: 0.55rem 0.9rem;
+  border: 1px solid #d4dae2;
+  border-radius: 8px;
+  background: #fff;
+  color: #2a3441;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.explore-nearme:hover {
+  border-color: #1f6feb;
+}
+
+.explore-nearme.is-active {
+  background: #1f6feb;
+  border-color: #1f6feb;
+  color: #fff;
+}
+
+.explore-geo-error {
+  color: #c0392b;
+  font-size: 0.85rem;
+  margin: -0.5rem 0 1rem;
+}
+
 .explore-count {
   color: #5f6b7a;
   font-size: 0.9rem;

--- a/frontend/src/Pages/Explore/Explore.jsx
+++ b/frontend/src/Pages/Explore/Explore.jsx
@@ -2,14 +2,13 @@ import { useState, useMemo, useEffect } from 'react';
 import Navbar from '../../Components/Navbar/Navbar.jsx';
 import EventComponent from '../../Components/EventComponent/EventComponent.jsx';
 import SearchBar from '../../Components/SearchBar/SearchBar.jsx';
-import { useUpcomingEvents } from '../../Hooks/UseEvents.jsx';
+import { useUpcomingEvents, useNearbyEvents } from '../../Hooks/UseEvents.jsx';
 import { useAuth } from '../../Hooks/UseAuth';
 import './Explore.css';
 
 const attendeeCount = (e) => e.attendees?.length || 0;
 
 export default function ExplorePage() {
-  const { events, loading, error } = useUpcomingEvents();
   const { user, isAuthenticated } = useAuth();
 
   const [selectedInterests, setSelectedInterests] = useState([]);
@@ -17,8 +16,24 @@ export default function ExplorePage() {
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState('soonest');
   const [myInterests, setMyInterests] = useState([]);
+  const [nearMe, setNearMe] = useState(false);
+  const [radiusKm, setRadiusKm] = useState(16);
+  const [userCoords, setUserCoords] = useState(null);
+  const [geoError, setGeoError] = useState('');
 
-  // Pull the signed-in user's interests to power the "For you" ranking.
+  // Location-bounded feed when "Near me" is on and we have coordinates;
+  // otherwise the full upcoming feed.
+  const usingNearby = nearMe && !!userCoords;
+  const upcoming = useUpcomingEvents();
+  const nearby = useNearbyEvents(
+    usingNearby ? userCoords : null,
+    radiusKm * 1000
+  );
+  const events = usingNearby ? nearby.events : upcoming.events;
+  const loading = usingNearby ? nearby.loading : upcoming.loading;
+  const error = usingNearby ? nearby.error : upcoming.error;
+
+  // Pull the signed-in user's interests (for "For you") and saved location.
   useEffect(() => {
     if (!isAuthenticated || !user?.token) {
       setMyInterests([]);
@@ -30,9 +45,15 @@ export default function ExplorePage() {
     })
       .then((res) => (res.ok ? res.json() : null))
       .then((json) => {
-        if (active && json?.success && Array.isArray(json.data?.interests)) {
+        if (!active || !json?.success) return;
+        if (Array.isArray(json.data?.interests)) {
           setMyInterests(json.data.interests);
           setSort('foryou');
+        }
+        const coords = json.data?.location?.coordinates;
+        if (Array.isArray(coords) && coords.length === 2) {
+          const [lng, lat] = coords;
+          if (lat != null && lng != null) setUserCoords({ lat, lng });
         }
       })
       .catch(() => {});
@@ -40,6 +61,33 @@ export default function ExplorePage() {
       active = false;
     };
   }, [isAuthenticated, user?.token]);
+
+  // Toggle "Near me": use the saved location, else ask the browser.
+  const toggleNearMe = () => {
+    setGeoError('');
+    if (nearMe) {
+      setNearMe(false);
+      return;
+    }
+    if (userCoords) {
+      setNearMe(true);
+      return;
+    }
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          setUserCoords({
+            lat: pos.coords.latitude,
+            lng: pos.coords.longitude,
+          });
+          setNearMe(true);
+        },
+        () => setGeoError('Couldn’t get your location.')
+      );
+    } else {
+      setGeoError('Location isn’t available in this browser.');
+    }
+  };
 
   const overlap = (eventInterests) =>
     eventInterests.filter((i) => myInterests.includes(i)).length;
@@ -112,6 +160,26 @@ export default function ExplorePage() {
               onChange={(e) => setQuery(e.target.value)}
               aria-label="Search events"
             />
+            <button
+              type="button"
+              className={`explore-nearme ${nearMe ? 'is-active' : ''}`}
+              onClick={toggleNearMe}
+              aria-pressed={nearMe}>
+              📍 Near me
+            </button>
+            {usingNearby && (
+              <label className="explore-sort">
+                Within:
+                <select
+                  value={radiusKm}
+                  onChange={(e) => setRadiusKm(Number(e.target.value))}>
+                  <option value={5}>5 km</option>
+                  <option value={16}>16 km</option>
+                  <option value={40}>40 km</option>
+                  <option value={100}>100 km</option>
+                </select>
+              </label>
+            )}
             <label className="explore-sort">
               Sort:
               <select value={sort} onChange={(e) => setSort(e.target.value)}>
@@ -123,6 +191,7 @@ export default function ExplorePage() {
               </select>
             </label>
           </div>
+          {geoError && <p className="explore-geo-error">{geoError}</p>}
 
           {loading ? (
             <div className="explore-grid" aria-hidden="true">

--- a/tests/unit/frontend/RegistrationModal.test.jsx
+++ b/tests/unit/frontend/RegistrationModal.test.jsx
@@ -75,6 +75,12 @@ const fillValidForm = () => {
 describe('RegistrationModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Hermetic geocode lookup (city -> coords): return no match so signup
+    // proceeds without a location and tests never hit the network.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
   });
 
   it('renders nothing when isOpen is false', () => {


### PR DESCRIPTION
## What & why
Captures a location for new users and adds a location-bounded feed — the "only load events in your area" behavior.

## Changes
- **`RegistrationModal`**: best-effort geocode of the entered city (OpenStreetMap Nominatim) on submit, passed as `location {latitude, longitude}` to `register` so the new user gets a 2dsphere point. Non-blocking — signup proceeds if geocoding fails.
- **`UseEvents`**: new `useNearbyEvents(coords, radiusMeters)` backed by the indexed `GET /events/nearby` (Phase 0). Idle when coords are null.
- **`Explore`**: a **"📍 Near me"** toggle + radius selector (5/16/40/100 km). Uses the signed-in user's saved location (`/users/me`) or browser geolocation; falls back to the full upcoming feed. All existing filters/sort apply on top of the bounded source.
- **Test**: hermetic `fetch` mock in the RegistrationModal test so the geocode call never hits the network.

## How tested
- Frontend unit suite green: **19 suites / 163 passing**.
- `npm run build --prefix frontend` succeeds. No eslint errors.
- CI runs the full suite as the gate.

Note: the Azure "Build and Deploy Job" (Static Web Apps PR preview) may show red due to a known staging-environment quota — unrelated to code; the authoritative `build` (Jest) and `ai-review` checks are the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)