### PR TITLE
Phase 3 (3A): marker clustering + spiderfy + new event pin

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,9 +11,11 @@
         "@cloudscape-design/components": "^3.0.1188",
         "date-fns": "^4.1.0",
         "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-leaflet": "^4.2.1",
+        "react-leaflet-cluster": "^2.1.0",
         "react-router-dom": "^7.9.5"
       },
       "devDependencies": {
@@ -2624,6 +2626,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2984,6 +2995,21 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "license": "SEE LICENSE IN <LICENSE>",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.8.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,11 @@
     "@cloudscape-design/components": "^3.0.1188",
     "date-fns": "^4.1.0",
     "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-leaflet": "^4.2.1",
+    "react-leaflet-cluster": "^2.1.0",
     "react-router-dom": "^7.9.5"
   },
   "devDependencies": {

--- a/frontend/src/Components/MainMapComponent/MainMapComponent.css
+++ b/frontend/src/Components/MainMapComponent/MainMapComponent.css
@@ -52,14 +52,35 @@
 }
 
 .event-marker-img {
-  width: 45px;
-  height: 45px;
+  width: 40px;
+  height: 52px;
   display: block;
   transition: transform 0.15s ease;
+  transform-origin: bottom center;
 }
 
 .event-marker-wrapper:hover .event-marker-img {
-  transform: translateY(-5px);
+  transform: translateY(-4px) scale(1.06);
+}
+
+/* Highlighted (selected) event pin — used by the linked split-view */
+.event-marker-wrapper.is-selected .event-marker-img {
+  transform: translateY(-4px) scale(1.18);
+  filter: drop-shadow(0 4px 8px rgba(29, 78, 216, 0.55));
+}
+
+/* Blue cluster bubbles to match the pin theme (overrides default green/yellow) */
+.marker-cluster-small,
+.marker-cluster-medium,
+.marker-cluster-large {
+  background-color: rgba(59, 130, 246, 0.25);
+}
+.marker-cluster-small div,
+.marker-cluster-medium div,
+.marker-cluster-large div {
+  background-color: rgba(29, 78, 216, 0.9);
+  color: #fff;
+  font-weight: 700;
 }
 
 /* Rounded zoom controls */

--- a/frontend/src/Components/MainMapComponent/MainMapComponent.jsx
+++ b/frontend/src/Components/MainMapComponent/MainMapComponent.jsx
@@ -1,20 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import MarkerClusterGroup from 'react-leaflet-cluster';
 import { useNavigate } from 'react-router-dom';
 import { useUpcomingEvents } from '../../Hooks/UseEvents';
 
 import 'leaflet/dist/leaflet.css';
+import 'leaflet.markercluster/dist/MarkerCluster.css';
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import L from 'leaflet';
-import markerIcon from '../../assets/pin.png';
+import markerIcon from '../../assets/event-pin.svg';
 import locateIcon from '../../assets/location.svg';
 import circle from '../../assets/circle.png';
 import './MainMapComponent.css';
 
 const EventIcon = L.divIcon({
-  html: `<img src="${markerIcon}" class="event-marker-img" />`,
-  iconSize: [45, 45],
-  iconAnchor: [22, 45],
-  popupAnchor: [0, -48],
+  html: `<img src="${markerIcon}" class="event-marker-img" alt="" />`,
+  iconSize: [40, 52],
+  iconAnchor: [20, 50],
+  popupAnchor: [0, -50],
   className: 'event-marker-wrapper',
 });
 
@@ -67,10 +70,16 @@ export default function MainMapComponent() {
           </Marker>
         )}
 
-        {/* Event markers */}
-        {events.map((event) => (
-          <EventMarker key={event.id} event={event} />
-        ))}
+        {/* Event markers — clustered; spiderfy spreads out same-venue pins */}
+        <MarkerClusterGroup
+          chunkedLoading
+          spiderfyOnMaxZoom
+          showCoverageOnHover={false}
+          maxClusterRadius={50}>
+          {events.map((event) => (
+            <EventMarker key={event.id} event={event} />
+          ))}
+        </MarkerClusterGroup>
 
         <LocateButton
           icon={locateIcon}

--- a/frontend/src/assets/event-pin.svg
+++ b/frontend/src/assets/event-pin.svg
@@ -1,0 +1,16 @@
+<svg width="40" height="52" viewBox="0 0 40 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="findrPin" x1="20" y1="1" x2="20" y2="50" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3b82f6" />
+      <stop offset="1" stop-color="#1d4ed8" />
+    </linearGradient>
+    <filter id="findrPinShadow" x="-30%" y="-10%" width="160%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#0f172a" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <path
+    d="M20 1.5C10.9 1.5 3.5 8.9 3.5 18c0 11.2 14 29.7 14.6 30.5a2.4 2.4 0 0 0 3.8 0C22.5 47.7 36.5 29.2 36.5 18 36.5 8.9 29.1 1.5 20 1.5z"
+    fill="url(#findrPin)" stroke="#ffffff" stroke-width="2.5" filter="url(#findrPinShadow)" />
+  <circle cx="20" cy="18" r="6.5" fill="#ffffff" />
+  <circle cx="20" cy="18" r="3" fill="#1d4ed8" />
+</svg>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -39,6 +39,8 @@ module.exports = {
         '^leaflet/dist/leaflet.css$': '<rootDir>/tests/__mocks__/styleMock.js',
         '\\.(svg|png|jpg|jpeg|gif)$': '<rootDir>/tests/__mocks__/fileMock.js',
         '^react-leaflet$': '<rootDir>/tests/__mocks__/react-leaflet.js',
+        '^react-leaflet-cluster$':
+          '<rootDir>/tests/__mocks__/react-leaflet-cluster.js',
         '^leaflet$': '<rootDir>/tests/__mocks__/leaflet.js',
         // Removed custom react and react-dom mappers to fix CI resolution errors
       },

--- a/tests/__mocks__/react-leaflet-cluster.js
+++ b/tests/__mocks__/react-leaflet-cluster.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+// Passthrough mock: render children directly so cluster contents (markers)
+// are still queryable in tests without pulling in leaflet.markercluster.
+export default function MarkerClusterGroup({ children }) {
+  return <div data-testid="marker-cluster-group">{children}</div>;
+}


### PR DESCRIPTION
## What & why
Map visual overhaul, part 1 of the Phase 3 Airbnb/Zillow split-view.

- **New SVG event pin** (`assets/event-pin.svg`) replacing `pin.png` — crisp teardrop with hover + selected states in CSS.
- **Clustering** via `react-leaflet-cluster` (+ `leaflet.markercluster`): nearby pins group into counts; **`spiderfyOnMaxZoom` spreads out multiple events at the same venue** so they no longer cover each other (the overlap issue). `showCoverageOnHover` off, `maxClusterRadius` 50.
- **Blue cluster-bubble theme** to match the pin.
- **Test**: passthrough mock for `react-leaflet-cluster` + jest `moduleNameMapper` entry so the unit suite stays green without loading `leaflet.markercluster`.

Deps (frontend/package.json): `react-leaflet-cluster ^2.1.0`, `leaflet.markercluster ^1.5.3` (compatible with react-leaflet 4.2.1 / react 18).

## How tested
- Frontend unit suite green: **19 suites / 163 passing**.
- `npm run build --prefix frontend` succeeds. No eslint errors. CI = gate.

Note: the Azure "Build and Deploy Job" (Static Web Apps PR preview) may show red on the known staging-env quota — unrelated to code; gate on `build` (Jest) + `ai-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)