### PR TITLE
Phase 3 (3B): linked split-view (two-way highlight) + mobile bottom-sheet

### DIFF
--- a/frontend/src/Components/EventColumn/EventColumn.jsx
+++ b/frontend/src/Components/EventColumn/EventColumn.jsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useUpcomingEvents } from '../../Hooks/UseEvents.jsx';
 import SearchBar from '../SearchBar/SearchBar.jsx';
 
-export default function EventColumn({ onRefetchReady }) {
+export default function EventColumn({ onRefetchReady, selectedId, onSelect }) {
   const { events: eventList, refetch } = useUpcomingEvents();
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [selectedInterests, setSelectedInterests] = useState([]);
@@ -59,6 +59,8 @@ export default function EventColumn({ onRefetchReady }) {
             attendees={event.attendees}
             host={event.host}
             interest={event.interests.join(', ')}
+            selected={event.id === selectedId}
+            onSelect={onSelect}
           />
         ))}
       </div>

--- a/frontend/src/Components/EventComponent/EventComponent.css
+++ b/frontend/src/Components/EventComponent/EventComponent.css
@@ -22,6 +22,13 @@
     0 0 0 1px rgba(124, 58, 237, 0.2);
 }
 
+/* Selected card — synced with the highlighted map pin (linked split-view) */
+.Event-Container--selected {
+  box-shadow:
+    0 6px 22px rgba(29, 78, 216, 0.25),
+    0 0 0 2px #1d4ed8;
+}
+
 /* ── Title with overflow handling ── */
 .Event-Title {
   font-weight: 700;

--- a/frontend/src/Components/EventComponent/EventComponent.jsx
+++ b/frontend/src/Components/EventComponent/EventComponent.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './EventComponent.css';
 import TagComponent from '../InterestTag/InterestTag.jsx';
@@ -10,6 +10,14 @@ export default function EventComponent(props) {
   const [attendees, setAttendees] = useState(props.attendees || []);
   const { openSignIn } = useModal();
   const navigate = useNavigate();
+  const cardRef = useRef(null);
+
+  // Scroll into view when this card becomes the selected one (map -> list sync).
+  useEffect(() => {
+    if (props.selected && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [props.selected]);
 
   const tags = props.interest
     ? props.interest.split(',').map((t) => t.trim())
@@ -70,7 +78,10 @@ export default function EventComponent(props) {
   };
 
   return (
-    <div className="Event-Container">
+    <div
+      ref={cardRef}
+      className={`Event-Container${props.selected ? ' Event-Container--selected' : ''}`}
+      onClick={() => props.onSelect?.(props.eventId)}>
       <div className="Event-Title">{props.eventName}</div>
       <hr className="Event-Divider" />
 

--- a/frontend/src/Components/MainMapComponent/MainMapComponent.jsx
+++ b/frontend/src/Components/MainMapComponent/MainMapComponent.jsx
@@ -13,13 +13,16 @@ import locateIcon from '../../assets/location.svg';
 import circle from '../../assets/circle.png';
 import './MainMapComponent.css';
 
-const EventIcon = L.divIcon({
-  html: `<img src="${markerIcon}" class="event-marker-img" alt="" />`,
-  iconSize: [40, 52],
-  iconAnchor: [20, 50],
-  popupAnchor: [0, -50],
-  className: 'event-marker-wrapper',
-});
+const makeEventIcon = (selected) =>
+  L.divIcon({
+    html: `<img src="${markerIcon}" class="event-marker-img" alt="" />`,
+    iconSize: [40, 52],
+    iconAnchor: [20, 50],
+    popupAnchor: [0, -50],
+    className: selected
+      ? 'event-marker-wrapper is-selected'
+      : 'event-marker-wrapper',
+  });
 
 const currentLocationIcon = L.icon({
   iconUrl: circle,
@@ -29,7 +32,7 @@ const currentLocationIcon = L.icon({
   popupAnchor: [0, -10],
 });
 
-export default function MainMapComponent() {
+export default function MainMapComponent({ selectedId = null, onSelect }) {
   const [userPosition, setUserPosition] = useState(null);
   const [tracking, setTracking] = useState(false);
   const { events: rawEvents } = useUpcomingEvents();
@@ -37,6 +40,8 @@ export default function MainMapComponent() {
   const events = rawEvents.filter(
     (e) => e.lat !== 0 && e.lng !== 0 && e.lat != null && e.lng != null
   );
+
+  const selectedEvent = events.find((e) => e.id === selectedId) || null;
 
   return (
     <div className="main-map-wrapper">
@@ -77,9 +82,17 @@ export default function MainMapComponent() {
           showCoverageOnHover={false}
           maxClusterRadius={50}>
           {events.map((event) => (
-            <EventMarker key={event.id} event={event} />
+            <EventMarker
+              key={event.id}
+              event={event}
+              isSelected={event.id === selectedId}
+              onSelect={onSelect}
+            />
           ))}
         </MarkerClusterGroup>
+
+        {/* Pan/zoom to the event selected from the side list */}
+        {selectedEvent && <FlyToSelected event={selectedEvent} />}
 
         <LocateButton
           icon={locateIcon}
@@ -94,8 +107,20 @@ export default function MainMapComponent() {
   );
 }
 
+// Pans/zooms the map to the event selected from the side list.
+function FlyToSelected({ event }) {
+  const map = useMap();
+  useEffect(() => {
+    if (event?.lat == null || event?.lng == null) return;
+    const targetZoom =
+      typeof map.getZoom === 'function' ? Math.max(map.getZoom(), 15) : 15;
+    map.flyTo([event.lat, event.lng], targetZoom, { duration: 0.6 });
+  }, [event?.id, map]);
+  return null;
+}
+
 // Individual event marker with popup
-function EventMarker({ event }) {
+function EventMarker({ event, isSelected = false, onSelect }) {
   const navigate = useNavigate();
 
   const formatTime = (isoString) => {
@@ -109,7 +134,10 @@ function EventMarker({ event }) {
   };
 
   return (
-    <Marker position={[event.lat, event.lng]} icon={EventIcon}>
+    <Marker
+      position={[event.lat, event.lng]}
+      icon={makeEventIcon(isSelected)}
+      eventHandlers={{ click: () => onSelect?.(event.id) }}>
       <Popup className="event-popup">
         <div className="popup-content">
           <div className="popup-title">{event.eventName}</div>

--- a/frontend/src/Pages/Home/HomePage.css
+++ b/frontend/src/Pages/Home/HomePage.css
@@ -139,3 +139,62 @@ body:has(.HomePage) {
 .col-closed .Create-Event-Button {
   left: 20px;
 }
+
+/* ── Mobile: event column becomes a bottom sheet ── */
+@media (max-width: 768px) {
+  .HomePage {
+    --event-col-w: 100vw;
+  }
+
+  .Event-Column {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 62vh;
+    max-height: 62vh;
+    border-top-left-radius: 18px;
+    border-top-right-radius: 18px;
+    box-shadow: 0 -6px 28px rgba(0, 0, 0, 0.22);
+    overflow: hidden;
+  }
+
+  /* Slide the sheet down off-screen when closed */
+  .col-closed .Event-Column {
+    transform: translateY(100%);
+  }
+
+  /* Close affordance becomes a top-center grab handle (arrow points down) */
+  .col-close-btn {
+    top: 8px;
+    right: 50%;
+    transform: translate(50%, 0) rotate(-90deg);
+  }
+
+  /* "Show events" pill floats at the bottom when the sheet is closed */
+  .col-open-btn {
+    top: auto;
+    bottom: 16px;
+    left: 50%;
+    width: auto;
+    height: 38px;
+    padding: 0 14px;
+    border-radius: 19px;
+    transform: translateX(-50%) translateY(8px);
+  }
+
+  .col-closed .col-open-btn {
+    transform: translateX(-50%) translateY(0);
+  }
+
+  .Create-Event-Button {
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: calc(62vh + 12px);
+  }
+
+  .col-closed .Create-Event-Button {
+    left: 50%;
+    bottom: 64px;
+  }
+}

--- a/frontend/src/Pages/Home/HomePage.jsx
+++ b/frontend/src/Pages/Home/HomePage.jsx
@@ -15,7 +15,14 @@ const MOBILE_BP = 768;
 export default function HomePage() {
   const [showModal, setShowModal] = useState(false);
   const [colOpen, setColOpen] = useState(() => window.innerWidth > MOBILE_BP);
+  const [selectedEventId, setSelectedEventId] = useState(null);
   const refetchEvents = useRef(null);
+
+  // Selecting from the map opens the list panel so the highlight is visible.
+  const handleSelectEvent = (id) => {
+    setSelectedEventId(id);
+    if (id && window.innerWidth <= MOBILE_BP) setColOpen(true);
+  };
   const { user } = useAuth();
   const { openSignIn } = useModal();
 
@@ -34,7 +41,10 @@ export default function HomePage() {
         <Navbar page="/" />
       </header>
       <div className="Map">
-        <MainMapComponent />
+        <MainMapComponent
+          selectedId={selectedEventId}
+          onSelect={handleSelectEvent}
+        />
       </div>
       <div className="Event-Column">
         <button
@@ -44,7 +54,11 @@ export default function HomePage() {
           aria-label="Close event panel">
           <img src={ArrowIcon} alt="" />
         </button>
-        <EventColumn onRefetchReady={(fn) => (refetchEvents.current = fn)} />
+        <EventColumn
+          onRefetchReady={(fn) => (refetchEvents.current = fn)}
+          selectedId={selectedEventId}
+          onSelect={handleSelectEvent}
+        />
       </div>
 
       {/* Hamburger – slides in when column is closed */}


### PR DESCRIPTION
## What & why
Completes the Phase 3 Airbnb/Zillow map UX: the map and the side list are now linked, and the list becomes a bottom sheet on mobile.

- **HomePage** lifts `selectedEventId` and passes it + a select handler to both the map and the event column. Selecting on the map also opens the list panel on mobile so the highlight is visible.
- **MainMapComponent**: clicking a marker selects that event; the selected pin renders a highlighted icon; a `FlyToSelected` helper pans/zooms to the event chosen from the list. New optional `selectedId`/`onSelect` props (backward compatible).
- **EventComponent**: clicking a card selects it; the selected card is outlined and **scrolls into view** (map → list sync). Props default off so Landing/Explore cards are unchanged.
- **EventColumn** forwards `selectedId`/`onSelect` to its cards.
- **Mobile bottom-sheet** (`HomePage.css`, ≤768px): the event column slides up from the bottom with a grab-handle close, a "show events" pill, and a repositioned create button.

## How tested
- Frontend unit suite green: **19 suites / 163 passing**.
- `npm run build --prefix frontend` succeeds. No eslint errors. CI = gate.

Note: Azure "Build and Deploy Job" (Static Web Apps PR preview) may be red on the known staging-env quota — not code; gate on `build` (Jest) + `ai-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)