### PR TITLE
Phase 4 (4A): profile bio + hosted-events list

### DIFF
--- a/backend/UserFiles/UserSchema.js
+++ b/backend/UserFiles/UserSchema.js
@@ -57,6 +57,12 @@ const UserSchema = new mongoose.Schema(
       required: false,
       trim: true,
     },
+    bio: {
+      type: String,
+      required: false,
+      trim: true,
+      maxlength: 500,
+    },
     interests: {
       type: [{ type: String }],
       required: false,

--- a/frontend/src/Pages/Profile/Profile.css
+++ b/frontend/src/Pages/Profile/Profile.css
@@ -698,3 +698,26 @@
   color: #f87171;
   box-shadow: 0 4px 16px rgba(239, 68, 68, 0.15);
 }
+
+/* ── Bio / About ── */
+.profile-bio-input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 90px;
+  font: inherit;
+}
+
+.profile-bio-count {
+  display: block;
+  text-align: right;
+  font-size: 0.75rem;
+  color: #8a93a2;
+  margin-top: 0.25rem;
+}
+
+.profile-bio-text {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}

--- a/frontend/src/Pages/Profile/Profile.jsx
+++ b/frontend/src/Pages/Profile/Profile.jsx
@@ -27,6 +27,8 @@ export default function Profile() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [attendingEvents, setAttendingEvents] = useState([]);
+  const [hostedEvents, setHostedEvents] = useState([]);
+  const [bio, setBio] = useState('');
 
   const {
     user,
@@ -65,6 +67,7 @@ export default function Profile() {
         setEmail(u.email || '');
         setAvatar(u.avatar || null);
         setAvatarPublicId(u.avatarPublicId || null); // load existing publicId
+        setBio(u.bio || '');
         setInterests(Array.isArray(u.interests) ? u.interests : []);
       } catch (err) {
         setErrorMsg(err.message);
@@ -88,8 +91,24 @@ export default function Profile() {
       }
     };
 
+    const fetchHostedEvents = async () => {
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/events/search/host/${user.id}`,
+          { headers: { Authorization: `Bearer ${user.token}` } }
+        );
+        const json = await res.json();
+        if (res.ok && json.success) {
+          setHostedEvents(json.data);
+        }
+      } catch {
+        setHostedEvents([]);
+      }
+    };
+
     fetchUser();
     fetchAttendingEvents();
+    fetchHostedEvents();
   }, [user, isAuthenticated, authLoading]);
 
   const handleImageUploadSuccess = async (result) => {
@@ -152,6 +171,7 @@ export default function Profile() {
             gender,
             city,
             email,
+            bio,
             interests,
           }),
         }
@@ -167,6 +187,7 @@ export default function Profile() {
       setGender(u.gender || '');
       setCity(u.city || '');
       setEmail(u.email || '');
+      setBio(u.bio || '');
       setInterests(Array.isArray(u.interests) ? u.interests : []);
       setIsEditing(false);
       updateProfileName(u.name);
@@ -212,6 +233,33 @@ export default function Profile() {
     setIsEditing(false);
     setErrorMsg('');
   };
+
+  // Shared renderer for the attending / hosting event lists.
+  const renderEventCard = (event) => (
+    <EventComponent
+      key={event._id}
+      eventId={event._id}
+      eventName={event.name}
+      eventDate={
+        event.time?.start ? new Date(event.time.start).toLocaleDateString() : ''
+      }
+      eventTime={
+        event.time?.start
+          ? new Date(event.time.start).toLocaleTimeString([], {
+              hour: 'numeric',
+              minute: '2-digit',
+            })
+          : ''
+      }
+      eventAddress={event.address}
+      description={event.description}
+      interest={
+        Array.isArray(event.interests) ? event.interests.join(', ') : ''
+      }
+      attendees={event.attendees}
+      host={event.host}
+    />
+  );
 
   if (authLoading || loading)
     return <div className="profile-loading">Loading…</div>;
@@ -370,6 +418,35 @@ export default function Profile() {
           <div className="profile-panel">
             <div className="profile-panel-header">
               <span className="panel-dot" />
+              <h3>About</h3>
+            </div>
+            <div className="profile-panel-body single">
+              <div className="profile-field">
+                {isEditing ? (
+                  <>
+                    <label>Bio</label>
+                    <textarea
+                      className="profile-bio-input"
+                      value={bio}
+                      onChange={(e) => setBio(e.target.value.slice(0, 500))}
+                      placeholder="Tell people a bit about yourself…"
+                      rows={4}
+                      maxLength={500}
+                    />
+                    <span className="profile-bio-count">{bio.length}/500</span>
+                  </>
+                ) : bio ? (
+                  <p className="profile-bio-text">{bio}</p>
+                ) : (
+                  <span className="profile-field-value empty">No bio yet</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="profile-panel">
+            <div className="profile-panel-header">
+              <span className="panel-dot" />
               <h3>Contact & Location</h3>
             </div>
             <div className="profile-panel-body">
@@ -474,40 +551,32 @@ export default function Profile() {
             <div className="profile-panel-body single profile-attending-body">
               {attendingEvents.length ? (
                 <div className="profile-attending-list">
-                  {attendingEvents.map((event) => (
-                    <EventComponent
-                      key={event._id}
-                      eventId={event._id}
-                      eventName={event.name}
-                      eventDate={
-                        event.time?.start
-                          ? new Date(event.time.start).toLocaleDateString()
-                          : ''
-                      }
-                      eventTime={
-                        event.time?.start
-                          ? new Date(event.time.start).toLocaleTimeString([], {
-                              hour: 'numeric',
-                              minute: '2-digit',
-                            })
-                          : ''
-                      }
-                      eventAddress={event.address}
-                      description={event.description}
-                      interest={
-                        Array.isArray(event.interests)
-                          ? event.interests.join(', ')
-                          : ''
-                      }
-                      attendees={event.attendees}
-                      host={event.host}
-                    />
-                  ))}
+                  {attendingEvents.map(renderEventCard)}
                 </div>
               ) : (
                 <div className="profile-attending-empty">
                   <span className="profile-field-value empty">
                     Not attending any events yet
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="profile-panel">
+            <div className="profile-panel-header">
+              <span className="panel-dot" />
+              <h3>Events I'm Hosting</h3>
+            </div>
+            <div className="profile-panel-body single profile-attending-body">
+              {hostedEvents.length ? (
+                <div className="profile-attending-list">
+                  {hostedEvents.map(renderEventCard)}
+                </div>
+              ) : (
+                <div className="profile-attending-empty">
+                  <span className="profile-field-value empty">
+                    You haven't hosted any events yet
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## What & why
First slice of Phase 4 (profiles & social), frontend-focused.

- **Bio**: added a `bio` field to `UserSchema` (String, max 500) so it persists; new **"About"** panel on the profile (textarea + live char counter when editing, paragraph when viewing). Bio is loaded, saved, and reset with the rest of the profile.
- **Hosted events**: new **"Events I'm Hosting"** panel via `GET /events/search/host/:id`, mirroring the existing "Events I'm Attending" list.
- Extracted a shared `renderEventCard` helper reused by both event lists (removes duplication).

## How tested
- Frontend unit suite green: **19 suites / 163 passing**.
- `npm run build --prefix frontend` succeeds; `node --check` on the schema OK; no eslint errors.
- No new backend deps (schema-only backend change).

Note: Azure "Build and Deploy Job" (Static Web Apps preview) may be red on the known staging-env quota — gate on `build` (Jest) + `ai-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)