### PR TITLE
Fix: stop cancelling production frontend deploys (SWA concurrency)

### DIFF
--- a/.github/workflows/static-web-app.yml
+++ b/.github/workflows/static-web-app.yml
@@ -9,9 +9,15 @@ on:
     branches:
       - main
 
+# Separate push (production) and pull_request (preview) into different
+# concurrency groups, and never cancel production deploys — only collapse
+# redundant PR-preview builds. Previously a single shared group with
+# cancel-in-progress:true was killing every production deploy on main
+# ("Canceling since a higher priority waiting request ... exists"), leaving
+# findr.page stale.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Production frontend deploys on `main` were all auto-cancelled ("higher priority waiting request for ...refs/heads/main exists") due to a shared concurrency group with `cancel-in-progress: true` across push + pull_request. The backend deployed fine but findr.page served stale frontend code (missing Phase 2C+ UI).

Fix: scope the concurrency group by `github.event_name` and only cancel in-progress for `pull_request` (preview) builds — production push deploys always run to completion. Verified by re-running the latest main deploy: findr.page now serves the current bundle (contains 'Near me', 'Events I'm Hosting').

🤖 Generated with [Claude Code](https://claude.com/claude-code)