### PR TITLE
Phase 4B: public profiles + host click-through

### DIFF
--- a/backend/UserFiles/UserRoutes.js
+++ b/backend/UserFiles/UserRoutes.js
@@ -249,10 +249,13 @@ router.get('/me', requireAuth, async (req, res) => {
     });
 });
 
-// Get a user by ID
+// Get a user's PUBLIC profile by ID. Unauthenticated and intentionally
+// projection-limited (no email/phone/dob/gender/location) — used by the public
+// profile page and event cards that show a host's name. For the logged-in
+// user's own full record, use GET /me (requireAuth).
 router.get('/:id', async (req, res) => {
   await userServices
-    .findUserById(req.params.id)
+    .findPublicProfileById(req.params.id)
     .then((user) => {
       if (!user)
         res.status(404).json({

--- a/backend/UserFiles/UserServices.js
+++ b/backend/UserFiles/UserServices.js
@@ -80,6 +80,14 @@ function findUserById(id) {
   return userModel.findById(id);
 }
 
+// Public-safe projection of a user — only fields safe to expose on a public
+// profile page. Excludes email, phone, dateOfBirth, gender, location, googleId.
+function findPublicProfileById(id) {
+  return userModel
+    .findById(id)
+    .select('name avatar bio interests city createdAt');
+}
+
 // Search users by name
 function findUserByName(name) {
   return userModel.find({ name: { $regex: name, $options: 'i' } });
@@ -193,6 +201,7 @@ export default {
   authenticateUser,
   getUsers,
   findUserById,
+  findPublicProfileById,
   findUserByName,
   findUserByEmail,
   findUserByPhoneNumber,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { ModalProvider, useModal } from './Components/ModalContext.jsx';
 import LandingPage from './Pages/Landing/Landing.jsx';
 import ExplorePage from './Pages/Explore/Explore.jsx';
 import Profile from './Pages/Profile/Profile.jsx';
+import PublicProfile from './Pages/PublicProfile/PublicProfile.jsx';
 import ProtectedRoute from './Components/ProtectedComponent.jsx';
 import EventDetails from './Pages/EventDetails/EventDetails.jsx';
 import './App.css';
@@ -44,6 +45,7 @@ function AppContent() {
               </ProtectedRoute>
             }
           />
+          <Route path="/users/:id" element={<PublicProfile />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route

--- a/frontend/src/Components/EventComponent/EventComponent.css
+++ b/frontend/src/Components/EventComponent/EventComponent.css
@@ -254,3 +254,23 @@
   background: rgba(124, 58, 237, 0.08);
   border-color: #7c3aed;
 }
+
+.Event-Host {
+  margin: 0.4rem 0 0.2rem;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.Event-Host-Link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #a78bfa;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.Event-Host-Link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/Components/EventComponent/EventComponent.jsx
+++ b/frontend/src/Components/EventComponent/EventComponent.jsx
@@ -106,6 +106,21 @@ export default function EventComponent(props) {
         )}
       </div>
 
+      {hostName && (
+        <div className="Event-Host">
+          Hosted by{' '}
+          <button
+            type="button"
+            className="Event-Host-Link"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (hostId) navigate(`/users/${hostId}`);
+            }}>
+            {hostName}
+          </button>
+        </div>
+      )}
+
       <div className="Tag-List">
         {tags.slice(0, 3).map((tag, idx) => (
           <TagComponent key={idx} Interest={tag} />

--- a/frontend/src/Pages/EventDetails/EventDetails.css
+++ b/frontend/src/Pages/EventDetails/EventDetails.css
@@ -970,3 +970,23 @@
   font-family: 'Consolas', monospace;
   font-size: 0.8rem;
 }
+
+.ed-host {
+  margin: 0.35rem 0 0;
+  font-size: 0.88rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.ed-host-link {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #a78bfa;
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.ed-host-link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/Pages/EventDetails/EventDetails.jsx
+++ b/frontend/src/Pages/EventDetails/EventDetails.jsx
@@ -222,6 +222,7 @@ export default function EventDetails() {
   const [comments, setComments] = useState(null);
   const [commentText, setCommentText] = useState('');
   const [commentsLoading, setCommentsLoading] = useState(true);
+  const [hostName, setHostName] = useState('');
 
   React.useEffect(() => {
     if (rawEvent) {
@@ -323,6 +324,24 @@ export default function EventDetails() {
 
     fetchUser();
   }, [isAuthenticated, user]);
+
+  // Resolve the host's display name for the "Hosted by" click-through link.
+  useEffect(() => {
+    const host = event?.host;
+    if (!host) return;
+    if (typeof host === 'object' && host.name) {
+      setHostName(host.name);
+      return;
+    }
+    const hostId = typeof host === 'object' ? host._id : host;
+    if (!hostId) return;
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/users/${hostId}`)
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.success && json.data?.name) setHostName(json.data.name);
+      })
+      .catch(() => {});
+  }, [event?.host]);
 
   if (loading) return <div className="ed-loading">Loading event…</div>;
   if (fetchError)
@@ -517,6 +536,24 @@ export default function EventDetails() {
                 {new Date(event.time.start).toLocaleString()} –{' '}
                 {new Date(event.time.end).toLocaleString()}
               </p>
+              {hostName &&
+                (() => {
+                  const hostId =
+                    typeof event.host === 'object'
+                      ? event.host?._id
+                      : event.host;
+                  return (
+                    <p className="ed-host">
+                      Hosted by{' '}
+                      <button
+                        type="button"
+                        className="ed-host-link"
+                        onClick={() => hostId && navigate(`/users/${hostId}`)}>
+                        {hostName}
+                      </button>
+                    </p>
+                  );
+                })()}
             </div>
           </div>
 

--- a/frontend/src/Pages/Profile/Profile.jsx
+++ b/frontend/src/Pages/Profile/Profile.jsx
@@ -51,7 +51,7 @@ export default function Profile() {
       setErrorMsg('');
       try {
         const res = await fetch(
-          `${import.meta.env.VITE_API_BASE_URL}/users/${user.id}`,
+          `${import.meta.env.VITE_API_BASE_URL}/users/me`,
           { headers: { Authorization: `Bearer ${user.token}` } }
         );
         const json = await res.json();

--- a/frontend/src/Pages/PublicProfile/PublicProfile.css
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.css
@@ -1,0 +1,192 @@
+.pub-page {
+  min-height: 100vh;
+  background: #080808;
+  padding-top: var(--nav-h, 72px);
+  color: #fff;
+}
+
+.pub-loading {
+  padding: 4rem 1.5rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 1rem;
+}
+
+.pub-back-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 0;
+}
+
+.pub-back {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0.4rem 0;
+  transition: color 0.15s ease;
+}
+
+.pub-back:hover {
+  color: #a78bfa;
+}
+
+.pub-layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+/* ── Sidebar ── */
+.pub-sidebar-card {
+  position: sticky;
+  top: calc(var(--nav-h, 72px) + 2rem);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.pub-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin: 0 auto 1rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(145deg, #1a0533, #2e1065);
+  border: 2px solid rgba(124, 58, 237, 0.4);
+}
+
+.pub-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.pub-avatar-initials {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #a78bfa;
+}
+
+.pub-name {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 0.5rem 0 0.25rem;
+}
+
+.pub-city {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.pub-stats {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pub-stat {
+  background: rgba(124, 58, 237, 0.1);
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  color: #a78bfa;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+}
+
+/* ── Main ── */
+.pub-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.pub-panel {
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.pub-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.pub-panel-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.pub-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #7c3aed;
+}
+
+.pub-panel-body {
+  padding: 1.5rem;
+}
+
+.pub-bio {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: pre-wrap;
+}
+
+.pub-empty {
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.9rem;
+}
+
+.pub-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pub-tag {
+  background: rgba(124, 58, 237, 0.1);
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  color: #a78bfa;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+}
+
+.pub-event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .pub-layout {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .pub-sidebar-card {
+    position: static;
+  }
+}

--- a/frontend/src/Pages/PublicProfile/PublicProfile.jsx
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.jsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import './PublicProfile.css';
+import Navbar from '../../Components/Navbar/Navbar';
+import EventComponent from '../../Components/EventComponent/EventComponent';
+import { useAuth } from '../../Hooks/UseAuth.ts';
+
+export default function PublicProfile() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [profile, setProfile] = useState(null);
+  const [hostedEvents, setHostedEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  // If the viewer lands on their own public profile, send them to the editable one.
+  useEffect(() => {
+    if (user?.id && id === user.id) navigate('/profile', { replace: true });
+  }, [id, user, navigate]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchProfile = async () => {
+      setLoading(true);
+      setErrorMsg('');
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/users/${id}`
+        );
+        const json = await res.json();
+        if (!res.ok || !json.success)
+          throw new Error(json.message || 'User not found');
+        if (!cancelled) setProfile(json.data);
+      } catch (err) {
+        if (!cancelled) setErrorMsg(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    const fetchHosted = async () => {
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/events/search/host/${id}`
+        );
+        const json = await res.json();
+        if (!cancelled && res.ok && json.success) setHostedEvents(json.data);
+      } catch {
+        if (!cancelled) setHostedEvents([]);
+      }
+    };
+
+    fetchProfile();
+    fetchHosted();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const renderEventCard = (event) => (
+    <EventComponent
+      key={event._id}
+      eventId={event._id}
+      eventName={event.name}
+      eventDate={
+        event.time?.start ? new Date(event.time.start).toLocaleDateString() : ''
+      }
+      eventTime={
+        event.time?.start
+          ? new Date(event.time.start).toLocaleTimeString([], {
+              hour: 'numeric',
+              minute: '2-digit',
+            })
+          : ''
+      }
+      eventAddress={event.address}
+      description={event.description}
+      interest={Array.isArray(event.interests) ? event.interests.join(', ') : ''}
+      attendees={event.attendees}
+      host={event.host}
+    />
+  );
+
+  if (loading) return <div className="pub-loading">Loading profile…</div>;
+  if (errorMsg)
+    return (
+      <div className="pub-page">
+        <Navbar page="/" />
+        <div className="pub-loading">{errorMsg}</div>
+      </div>
+    );
+
+  const interests = Array.isArray(profile?.interests) ? profile.interests : [];
+
+  return (
+    <div className="pub-page">
+      <Navbar page="/" />
+
+      <div className="pub-back-wrapper">
+        <button className="pub-back" onClick={() => navigate(-1)}>
+          ← Back
+        </button>
+      </div>
+
+      <div className="pub-layout">
+        <aside className="pub-sidebar">
+          <div className="pub-sidebar-card">
+            <div className="pub-avatar">
+              {profile?.avatar ? (
+                <img
+                  src={profile.avatar}
+                  alt={profile.name}
+                  className="pub-avatar-img"
+                />
+              ) : (
+                <div className="pub-avatar-initials">
+                  {(profile?.name?.charAt(0) || '?').toUpperCase()}
+                </div>
+              )}
+            </div>
+
+            <p className="pub-name">{profile?.name || '—'}</p>
+            {profile?.city && <p className="pub-city">{profile.city}</p>}
+
+            {interests.length > 0 && (
+              <div className="pub-stats">
+                <span className="pub-stat">
+                  {interests.length} interest
+                  {interests.length !== 1 ? 's' : ''}
+                </span>
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <div className="pub-main">
+          <div className="pub-panel">
+            <div className="pub-panel-header">
+              <span className="pub-dot" />
+              <h3>About</h3>
+            </div>
+            <div className="pub-panel-body">
+              {profile?.bio ? (
+                <p className="pub-bio">{profile.bio}</p>
+              ) : (
+                <span className="pub-empty">No bio yet</span>
+              )}
+            </div>
+          </div>
+
+          <div className="pub-panel">
+            <div className="pub-panel-header">
+              <span className="pub-dot" />
+              <h3>Interests</h3>
+            </div>
+            <div className="pub-panel-body">
+              {interests.length ? (
+                <div className="pub-tags">
+                  {interests.map((tag, idx) => (
+                    <span key={idx} className="pub-tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="pub-empty">No interests added yet</span>
+              )}
+            </div>
+          </div>
+
+          <div className="pub-panel">
+            <div className="pub-panel-header">
+              <span className="pub-dot" />
+              <h3>Hosted Events</h3>
+            </div>
+            <div className="pub-panel-body">
+              {hostedEvents.length ? (
+                <div className="pub-event-list">
+                  {hostedEvents.map(renderEventCard)}
+                </div>
+              ) : (
+                <span className="pub-empty">No hosted events yet</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/Integration/Users/user.routes.test.js
+++ b/tests/Integration/Users/user.routes.test.js
@@ -219,15 +219,20 @@ describe('User Routes', () => {
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    test('GET /users/:id returns a user', async () => {
+    test('GET /users/:id returns a public-safe profile', async () => {
       const registerRes = await request(app).post('/users').send(testUser);
       const userId = registerRes.body.user._id;
 
       const res = await request(app).get(`/users/${userId}`);
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(res.body.data.email).toBe('test@example.com');
-      expect(res.body.data.password).toBeUndefined(); // password should not be returned
+      expect(res.body.data.name).toBe(testUser.name);
+      // Public endpoint must NOT leak PII or credentials.
+      expect(res.body.data.password).toBeUndefined();
+      expect(res.body.data.email).toBeUndefined();
+      expect(res.body.data.phoneNumber).toBeUndefined();
+      expect(res.body.data.dateOfBirth).toBeUndefined();
+      expect(res.body.data.gender).toBeUndefined();
     });
 
     test('GET /users/:id returns 404 for missing user', async () => {


### PR DESCRIPTION
## Summary
- Public profile page at `/users/:id` — avatar, bio, interests, hosted events (self-views redirect to editable `/profile`).
- Clickable **"Hosted by <name>"** on event cards and the event-details header → host's public profile.
- **Security fix:** unauthenticated `GET /users/:id` was returning full user docs (email, phone, DOB, gender). It now returns a public-safe projection only. The Profile page reads its own full record via authenticated `GET /users/me`.

## Test plan
- `npm run build` (frontend) ✅
- `jest unit-frontend` — 163 passed ✅
- Manual: open a host's profile from an event card / event details; confirm no PII in `/users/:id` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)