### PR TITLE
Phase 4C: Cal Poly verified-student badge

### DIFF
--- a/backend/OAuth/GoogleAuthRoutes.js
+++ b/backend/OAuth/GoogleAuthRoutes.js
@@ -19,6 +19,7 @@ const envPath = [
 });
 config({ path: envPath });
 import User from '../UserFiles/UserSchema.js';
+import { isStudentEmail } from '../utils/studentEmail.js';
 
 const router = express.Router();
 
@@ -36,15 +37,23 @@ passport.use(
     async (accessToken, refreshToken, profile, done) => {
       console.log('Google profile:', profile);
       try {
+        const email = profile.emails?.[0]?.value;
+        const verifiedStudent = isStudentEmail(email);
+
         let user = await User.findOne({ googleId: profile.id });
 
         if (!user) {
           user = await User.create({
             googleId: profile.id,
-            email: profile.emails?.[0]?.value,
+            email,
             name: profile.displayName,
             avatar: profile.photos?.[0]?.value,
+            isVerifiedStudent: verifiedStudent,
           });
+        } else if (user.isVerifiedStudent !== verifiedStudent) {
+          // Keep the badge in sync if the account's student status changed.
+          user.isVerifiedStudent = verifiedStudent;
+          await user.save();
         }
 
         return done(null, user);

--- a/backend/UserFiles/UserSchema.js
+++ b/backend/UserFiles/UserSchema.js
@@ -63,6 +63,13 @@ const UserSchema = new mongoose.Schema(
       trim: true,
       maxlength: 500,
     },
+    // True when the account's email is on the recognized student domain
+    // (e.g. @calpoly.edu). Drives the "Verified Student" badge and unlocks
+    // student-/club-only events. Derived from email, never set by the client.
+    isVerifiedStudent: {
+      type: Boolean,
+      default: false,
+    },
     interests: {
       type: [{ type: String }],
       required: false,

--- a/backend/UserFiles/UserServices.js
+++ b/backend/UserFiles/UserServices.js
@@ -1,6 +1,7 @@
 import userModel from './UserSchema.js';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
+import { isStudentEmail } from '../utils/studentEmail.js';
 
 /*
  * Helper functions for authentication
@@ -24,6 +25,14 @@ async function authenticateUser(email, password) {
 
   const isValid = await comparePassword(user, password);
   if (!isValid) return null;
+
+  // Keep the verified-student badge in sync for accounts created before the
+  // field existed (or if the domain list changed).
+  const verifiedStudent = isStudentEmail(user.email);
+  if (user.isVerifiedStudent !== verifiedStudent) {
+    user.isVerifiedStudent = verifiedStudent;
+    await user.save();
+  }
 
   // Generate access token (short-lived)
   const accessToken = jwt.sign({ id: user._id }, process.env.JWT_TOKEN_SECRET, {
@@ -58,6 +67,9 @@ async function addUser(user) {
     throw error;
   }
   const formatteduser = formatUser(user);
+  // Derive verified-student status from the email domain — never trust a
+  // client-supplied flag.
+  formatteduser.isVerifiedStudent = isStudentEmail(user.email);
   const newUser = new userModel(formatteduser);
   return await newUser.save();
 }
@@ -69,7 +81,15 @@ function deleteUser(id) {
 
 // Update a user
 function updateUser(id, userData) {
-  return userModel.findByIdAndUpdate(id, userData, {
+  // Strip server-controlled fields so a client can't self-grant them via PUT.
+  const {
+    isVerifiedStudent,
+    googleId,
+    password,
+    _id,
+    ...safeData
+  } = userData || {};
+  return userModel.findByIdAndUpdate(id, safeData, {
     new: true,
     runValidators: true,
   });
@@ -85,7 +105,7 @@ function findUserById(id) {
 function findPublicProfileById(id) {
   return userModel
     .findById(id)
-    .select('name avatar bio interests city createdAt');
+    .select('name avatar bio interests city createdAt isVerifiedStudent');
 }
 
 // Search users by name

--- a/backend/utils/studentEmail.js
+++ b/backend/utils/studentEmail.js
@@ -1,0 +1,23 @@
+// Recognized student email domain(s). Defaults to Cal Poly; override with the
+// STUDENT_EMAIL_DOMAINS env var (comma-separated) to support more schools.
+const STUDENT_DOMAINS = (process.env.STUDENT_EMAIL_DOMAINS || 'calpoly.edu')
+  .split(',')
+  .map((d) => d.trim().toLowerCase())
+  .filter(Boolean);
+
+/**
+ * Returns true if the given email belongs to a recognized student domain.
+ * @param {string} email
+ * @returns {boolean}
+ */
+export function isStudentEmail(email) {
+  if (!email || typeof email !== 'string') return false;
+  const domain = email.trim().toLowerCase().split('@')[1];
+  if (!domain) return false;
+  // Match the domain or any subdomain (e.g. mail.calpoly.edu).
+  return STUDENT_DOMAINS.some(
+    (d) => domain === d || domain.endsWith(`.${d}`)
+  );
+}
+
+export default isStudentEmail;

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.css
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.css
@@ -246,3 +246,15 @@
 .modal__switch:hover {
   text-decoration: underline;
 }
+
+.modal__student-hint {
+  margin: 0.85rem 0 0;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.modal__student-hint strong {
+  color: #34d399;
+}

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
@@ -121,6 +121,11 @@ export default function SignInModal({ isOpen, onClose, onSwitchToRegister }) {
           Continue with Google
         </button>
 
+        <p className="modal__student-hint">
+          🎓 Use your <strong>@calpoly.edu</strong> email to get a Verified
+          Student badge and access club &amp; campus events.
+        </p>
+
         <p className="modal__footer">
           Don't have an account?{' '}
           <button

--- a/frontend/src/Components/VerifiedBadge/VerifiedBadge.css
+++ b/frontend/src/Components/VerifiedBadge/VerifiedBadge.css
@@ -1,0 +1,35 @@
+.verified-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #34d399;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.verified-badge-icon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
+
+.verified-badge--sm {
+  font-size: 0.72rem;
+}
+
+.verified-badge--md {
+  font-size: 0.85rem;
+}
+
+.verified-badge--lg {
+  font-size: 1rem;
+}
+
+/* Pill variant when used standalone */
+.verified-badge--pill {
+  background: rgba(52, 211, 153, 0.12);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+}

--- a/frontend/src/Components/VerifiedBadge/VerifiedBadge.jsx
+++ b/frontend/src/Components/VerifiedBadge/VerifiedBadge.jsx
@@ -1,0 +1,23 @@
+import './VerifiedBadge.css';
+
+// Small "Verified Student" badge shown for accounts on a recognized student
+// email domain (e.g. @calpoly.edu). Render only when isVerifiedStudent is true.
+export default function VerifiedBadge({ size = 'md', label = 'Verified Student' }) {
+  return (
+    <span
+      className={`verified-badge verified-badge--${size}`}
+      title="Verified student — signed in with a school email">
+      <svg viewBox="0 0 24 24" className="verified-badge-icon" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M12 1l2.6 1.9 3.2-.1 1 3.05 2.6 1.85-1 3.05L23 15l-2.6 1.85 1 3.05-3.2-.1L15.6 21 12 19.1 8.4 21l-1.8-2.25-3.2.1 1-3.05L1 13.85 3.6 12l-1-3.05 3.2.1L7.4 6 12 1z"
+        />
+        <path
+          fill="#080808"
+          d="M10.6 14.6l-2.3-2.3-1.1 1.1 3.4 3.4 6-6-1.1-1.1z"
+        />
+      </svg>
+      {label && <span className="verified-badge-text">{label}</span>}
+    </span>
+  );
+}

--- a/frontend/src/Pages/Profile/Profile.css
+++ b/frontend/src/Pages/Profile/Profile.css
@@ -721,3 +721,9 @@
   white-space: pre-wrap;
   line-height: 1.5;
 }
+
+.sidebar-verified {
+  display: flex;
+  justify-content: center;
+  margin: 0.1rem 0 0.4rem;
+}

--- a/frontend/src/Pages/Profile/Profile.jsx
+++ b/frontend/src/Pages/Profile/Profile.jsx
@@ -6,6 +6,7 @@ import ProfileImageUploadModal from '../../Components/Modals/ProfileImageUploadM
 import DeleteAccountModal from '../../Components/DeleteAccountModal/DeleteAccountModal';
 import { useNavigate } from 'react-router-dom';
 import EventComponent from '../../Components/EventComponent/EventComponent';
+import VerifiedBadge from '../../Components/VerifiedBadge/VerifiedBadge';
 
 export default function Profile() {
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ export default function Profile() {
   const [attendingEvents, setAttendingEvents] = useState([]);
   const [hostedEvents, setHostedEvents] = useState([]);
   const [bio, setBio] = useState('');
+  const [isVerifiedStudent, setIsVerifiedStudent] = useState(false);
 
   const {
     user,
@@ -68,6 +70,7 @@ export default function Profile() {
         setAvatar(u.avatar || null);
         setAvatarPublicId(u.avatarPublicId || null); // load existing publicId
         setBio(u.bio || '');
+        setIsVerifiedStudent(!!u.isVerifiedStudent);
         setInterests(Array.isArray(u.interests) ? u.interests : []);
       } catch (err) {
         setErrorMsg(err.message);
@@ -305,6 +308,11 @@ export default function Profile() {
             </button>
 
             <p className="sidebar-name">{name || '—'}</p>
+            {isVerifiedStudent && (
+              <div className="sidebar-verified">
+                <VerifiedBadge size="sm" />
+              </div>
+            )}
             <p className="sidebar-email">{email}</p>
 
             {(interests.length > 0 || city) && (

--- a/frontend/src/Pages/PublicProfile/PublicProfile.css
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.css
@@ -190,3 +190,9 @@
     position: static;
   }
 }
+
+.pub-verified {
+  display: flex;
+  justify-content: center;
+  margin: 0.1rem 0 0.4rem;
+}

--- a/frontend/src/Pages/PublicProfile/PublicProfile.jsx
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.jsx
@@ -4,6 +4,7 @@ import './PublicProfile.css';
 import Navbar from '../../Components/Navbar/Navbar';
 import EventComponent from '../../Components/EventComponent/EventComponent';
 import { useAuth } from '../../Hooks/UseAuth.ts';
+import VerifiedBadge from '../../Components/VerifiedBadge/VerifiedBadge';
 
 export default function PublicProfile() {
   const { id } = useParams();
@@ -123,6 +124,11 @@ export default function PublicProfile() {
             </div>
 
             <p className="pub-name">{profile?.name || '—'}</p>
+            {profile?.isVerifiedStudent && (
+              <div className="pub-verified">
+                <VerifiedBadge size="sm" />
+              </div>
+            )}
             {profile?.city && <p className="pub-city">{profile.city}</p>}
 
             {interests.length > 0 && (

--- a/tests/unit/backend/studentEmail.test.js
+++ b/tests/unit/backend/studentEmail.test.js
@@ -1,0 +1,29 @@
+import { isStudentEmail } from '../../../backend/utils/studentEmail.js';
+
+describe('isStudentEmail', () => {
+  test('accepts a @calpoly.edu address', () => {
+    expect(isStudentEmail('jdoe@calpoly.edu')).toBe(true);
+  });
+
+  test('accepts a subdomain of calpoly.edu', () => {
+    expect(isStudentEmail('jdoe@mail.calpoly.edu')).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isStudentEmail('JDOE@CalPoly.EDU')).toBe(true);
+  });
+
+  test('rejects a non-student domain', () => {
+    expect(isStudentEmail('jdoe@gmail.com')).toBe(false);
+  });
+
+  test('rejects a lookalike domain', () => {
+    expect(isStudentEmail('jdoe@notcalpoly.edu')).toBe(false);
+  });
+
+  test('handles empty / malformed input', () => {
+    expect(isStudentEmail('')).toBe(false);
+    expect(isStudentEmail(null)).toBe(false);
+    expect(isStudentEmail('no-at-sign')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `isVerifiedStudent` user flag, **server-derived from the email domain** (never client-set). Defaults to `calpoly.edu`, configurable via `STUDENT_EMAIL_DOMAINS`.
- Applied on Google OAuth signup, email/password signup, and re-synced on every login (backfills existing accounts).
- **Verified Student badge** shown on own profile + public profiles; Cal Poly hint under the Google button in the sign-in modal.
- **Hardening:** `PUT /users/:id` now strips `isVerifiedStudent`/`googleId`/`password`/`_id` so a client can't self-grant the badge.

This sets up the `@calpoly.edu` gating that Phase 5 (clubs) will use to unlock club/campus events.

## Test plan
- `npm run build` ✅
- `jest unit-frontend` — 169 passed (6 new `isStudentEmail` unit tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)