### PR TITLE
Phase 7 (part 1): mobile responsiveness — navbar, landing, modals

### DIFF
--- a/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
+++ b/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
@@ -368,3 +368,14 @@
   color: #1f6feb;
   font-weight: 600;
 }
+
+/* ── Mobile ── */
+@media (max-width: 560px) {
+  .rmodal__card {
+    padding: 1.75rem 1.25rem 1.5rem;
+  }
+
+  .rmodal__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.css
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.css
@@ -7,6 +7,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 1rem;
+  overflow-y: auto;
   animation: overlay-in 0.2s ease;
 }
 
@@ -27,8 +29,16 @@
   padding: 2.5rem 2.25rem 2rem;
   width: 100%;
   max-width: 400px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
   animation: card-in 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (max-width: 480px) {
+  .modal__card {
+    padding: 1.75rem 1.25rem 1.5rem;
+  }
 }
 
 @keyframes card-in {

--- a/frontend/src/Components/Navbar/Navbar.css
+++ b/frontend/src/Components/Navbar/Navbar.css
@@ -232,3 +232,66 @@ body {
 .navbar__hamburger {
   display: none;
 }
+
+/* ── Tablet ── */
+@media (max-width: 768px) {
+  .navbar {
+    padding: 0 1.25rem;
+  }
+}
+
+/* ── Mobile ── */
+@media (max-width: 560px) {
+  .navbar {
+    padding: 0 0.85rem;
+    gap: 0.5rem;
+  }
+
+  /* Pull the centered Explore link back into normal flow so it can't overlap
+     the logo or the auth buttons on narrow screens. */
+  .navbar__explore {
+    position: static;
+    left: auto;
+    transform: none;
+    flex: 1;
+    text-align: center;
+  }
+
+  .navbar__logo h2 {
+    font-size: 1.15rem;
+    letter-spacing: 1px;
+  }
+
+  .navbar__explore-link {
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+  }
+
+  .navbar__links {
+    gap: 0.4rem;
+  }
+
+  .navbar__link.signin,
+  .navbar__link.signup,
+  .navbar__logout-btn {
+    padding: 0.35rem 0.7rem;
+    font-size: 0.78rem;
+  }
+
+  .navbar__profile {
+    gap: 0.5rem;
+  }
+
+  .navbar__profile-icon,
+  .navbar__profile-initial {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+/* ── Very small phones ── */
+@media (max-width: 380px) {
+  .navbar__link.signin {
+    display: none; /* keep the primary "Registration" CTA, drop secondary */
+  }
+}

--- a/frontend/src/Pages/Landing/Landing.css
+++ b/frontend/src/Pages/Landing/Landing.css
@@ -288,3 +288,61 @@ main {
 .footer-links a:hover {
   text-decoration: underline;
 }
+
+/* ── Responsive / mobile ── */
+@media (max-width: 900px) {
+  .feature-content.image-layout {
+    flex-direction: column;
+  }
+
+  .feature-text {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .hero-subtitle {
+    font-size: 1.05rem;
+  }
+
+  .hero-content {
+    padding: 1rem;
+  }
+
+  .feature-text h2,
+  .feature-content h2 {
+    font-size: 1.9rem;
+  }
+
+  .feature-text p,
+  .feature-content p {
+    font-size: 1.05rem;
+  }
+
+  .features {
+    gap: 1.5rem;
+    padding: 2rem 1rem;
+  }
+
+  /* Fixed 500px-wide, 100px-padded cards overflow small screens. */
+  .feature {
+    width: 100%;
+    max-width: 420px;
+    padding: 2rem;
+    box-sizing: border-box;
+  }
+
+  .newsletter-form {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 420px) {
+  .hero-title {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
First pass of the mobile/UI-polish phase, targeting the components with **no** responsive handling:
- **Navbar** — the centered "Explore" link was absolutely positioned and overlapped the logo/auth buttons on phones. Now flows normally < 560px, with tighter padding, smaller avatar/buttons, and the secondary "Sign In" hidden on very small screens.
- **Landing** — stacks the image feature row, scales the hero title down, fixes fixed-500px feature cards that overflowed, stacks the newsletter form.
- **Auth modals** — overlay padding + scroll so tall registration content never clips; registration 2-col grid stacks on mobile.

Explore, EventDetails, Profile, PublicProfile and the map bottom-sheet already had breakpoints.

## Test plan
- `npm run build` ✅
- `jest unit-frontend` — 169 passed ✅
- Manual: check navbar/landing/modals at 375px width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)