### PR TITLE
Phase 5B: clubs frontend (browse/join, register, admin dashboard)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,8 @@ import LandingPage from './Pages/Landing/Landing.jsx';
 import ExplorePage from './Pages/Explore/Explore.jsx';
 import Profile from './Pages/Profile/Profile.jsx';
 import PublicProfile from './Pages/PublicProfile/PublicProfile.jsx';
+import Clubs from './Pages/Clubs/Clubs.jsx';
+import AdminDashboard from './Pages/AdminDashboard/AdminDashboard.jsx';
 import ProtectedRoute from './Components/ProtectedComponent.jsx';
 import EventDetails from './Pages/EventDetails/EventDetails.jsx';
 import './App.css';
@@ -46,6 +48,8 @@ function AppContent() {
             }
           />
           <Route path="/users/:id" element={<PublicProfile />} />
+          <Route path="/clubs" element={<Clubs />} />
+          <Route path="/admin" element={<AdminDashboard />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route

--- a/frontend/src/Components/Navbar/Navbar.css
+++ b/frontend/src/Components/Navbar/Navbar.css
@@ -47,6 +47,8 @@ body {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  gap: 1.75rem;
 }
 
 /* ── Explore link ── */
@@ -229,6 +231,26 @@ body {
   background: rgba(124, 58, 237, 0.1);
 }
 
+.navbar__admin {
+  border: 1px solid rgba(124, 58, 237, 0.5);
+  color: #a78bfa;
+  padding: 0.35rem 0.8rem;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 0.82rem;
+}
+
+.navbar__admin:hover {
+  background: rgba(124, 58, 237, 0.12);
+  color: #fff;
+}
+
+.navbar__admin.active {
+  background: rgba(124, 58, 237, 0.2);
+  color: #fff;
+  border-bottom: 1px solid rgba(124, 58, 237, 0.5);
+}
+
 .navbar__hamburger {
   display: none;
 }
@@ -254,7 +276,8 @@ body {
     left: auto;
     transform: none;
     flex: 1;
-    text-align: center;
+    justify-content: center;
+    gap: 0.9rem;
   }
 
   .navbar__logo h2 {

--- a/frontend/src/Components/Navbar/Navbar.jsx
+++ b/frontend/src/Components/Navbar/Navbar.jsx
@@ -26,6 +26,13 @@ export default function Navbar({ page = '/' }) {
           }>
           Explore
         </NavLink>
+        <NavLink
+          to="/clubs"
+          className={({ isActive }) =>
+            isActive ? 'navbar__explore-link active' : 'navbar__explore-link'
+          }>
+          Clubs
+        </NavLink>
       </div>
 
       <div className="navbar__links">
@@ -40,6 +47,17 @@ export default function Navbar({ page = '/' }) {
           </>
         ) : (
           <div className="navbar__profile">
+            {user?.isAdmin && (
+              <NavLink
+                to="/admin"
+                className={({ isActive }) =>
+                  isActive
+                    ? 'navbar__link navbar__admin active'
+                    : 'navbar__link navbar__admin'
+                }>
+                Admin
+              </NavLink>
+            )}
             <button onClick={logout} className="navbar__logout-btn">
               Logout
             </button>

--- a/frontend/src/Components/RegisterClubModal/RegisterClubModal.css
+++ b/frontend/src/Components/RegisterClubModal/RegisterClubModal.css
@@ -1,0 +1,158 @@
+.rcm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.rcm-card {
+  position: relative;
+  background: #111;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 540px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  color: #fff;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+}
+
+.rcm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rcm-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.rcm-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.rcm-note {
+  margin: 0.5rem 0 1.25rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+}
+
+.rcm-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rcm-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.rcm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.rcm-field span {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.rcm-field input,
+.rcm-field select,
+.rcm-field textarea {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  color: #fff;
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.rcm-field input:focus,
+.rcm-field select:focus,
+.rcm-field textarea:focus {
+  outline: none;
+  border-color: rgba(124, 58, 237, 0.6);
+}
+
+.rcm-field option {
+  background: #111;
+}
+
+.rcm-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+}
+
+.rcm-checkbox input {
+  margin-top: 0.15rem;
+}
+
+.rcm-error {
+  color: #f87171;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.rcm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.rcm-btn {
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.rcm-btn--ghost {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.rcm-btn--primary {
+  background: #7c3aed;
+  color: #fff;
+}
+
+.rcm-btn--primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+@media (max-width: 480px) {
+  .rcm-card {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .rcm-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/Components/RegisterClubModal/RegisterClubModal.jsx
+++ b/frontend/src/Components/RegisterClubModal/RegisterClubModal.jsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import './RegisterClubModal.css';
+import { useAuth } from '../../Hooks/UseAuth.ts';
+
+const API = import.meta.env.VITE_API_BASE_URL;
+
+const CATEGORIES = [
+  'Academic',
+  'Sports & Recreation',
+  'Arts & Music',
+  'Cultural',
+  'Greek Life',
+  'Service & Volunteering',
+  'Professional',
+  'Gaming',
+  'Other',
+];
+
+export default function RegisterClubModal({ isOpen, onClose, onSuccess }) {
+  const { user } = useAuth();
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    category: '',
+    description: '',
+    studentOnly: false,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  if (!isOpen) return null;
+
+  const update = (field) => (e) =>
+    setForm((f) => ({
+      ...f,
+      [field]: e.target.type === 'checkbox' ? e.target.checked : e.target.value,
+    }));
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (!form.name.trim() || !form.email.trim()) {
+      setError('Club name and contact email are required.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${API}/organizations`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user?.token}`,
+        },
+        body: JSON.stringify(form),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success)
+        throw new Error(json.message || 'Failed to register club');
+      onSuccess?.(json.data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="rcm-overlay" onClick={onClose}>
+      <div className="rcm-card" onClick={(e) => e.stopPropagation()}>
+        <div className="rcm-header">
+          <h2>Register your club</h2>
+          <button className="rcm-close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        <p className="rcm-note">
+          Submissions are reviewed by a Findr admin before going live.
+        </p>
+
+        <form className="rcm-form" onSubmit={handleSubmit} noValidate>
+          <label className="rcm-field">
+            <span>Club name *</span>
+            <input value={form.name} onChange={update('name')} required />
+          </label>
+
+          <div className="rcm-grid">
+            <label className="rcm-field">
+              <span>Contact email *</span>
+              <input
+                type="email"
+                value={form.email}
+                onChange={update('email')}
+                required
+              />
+            </label>
+            <label className="rcm-field">
+              <span>Phone</span>
+              <input value={form.phone} onChange={update('phone')} />
+            </label>
+          </div>
+
+          <label className="rcm-field">
+            <span>Category</span>
+            <select value={form.category} onChange={update('category')}>
+              <option value="">Select a category</option>
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="rcm-field">
+            <span>Description</span>
+            <textarea
+              rows={4}
+              maxLength={1000}
+              value={form.description}
+              onChange={update('description')}
+              placeholder="What is your club about?"
+            />
+          </label>
+
+          <label className="rcm-checkbox">
+            <input
+              type="checkbox"
+              checked={form.studentOnly}
+              onChange={update('studentOnly')}
+            />
+            <span>
+              Students only — only verified students can join &amp; see our
+              events
+            </span>
+          </label>
+
+          {error && <p className="rcm-error">{error}</p>}
+
+          <div className="rcm-actions">
+            <button
+              type="button"
+              className="rcm-btn rcm-btn--ghost"
+              onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rcm-btn rcm-btn--primary"
+              disabled={submitting}>
+              {submitting ? 'Submitting…' : 'Submit for review'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Hooks/UseAuth.ts
+++ b/frontend/src/Hooks/UseAuth.ts
@@ -21,6 +21,8 @@ interface UserState {
   token: string;
   name?: string;
   avatar?: string | null;
+  isAdmin?: boolean;
+  isVerifiedStudent?: boolean;
 }
 
 export const AuthContext = createContext(null);
@@ -44,7 +46,7 @@ export const useProvideAuth = () => {
   ): Promise<Partial<UserState>> => {
     try {
       const res = await fetch(
-        `${import.meta.env.VITE_API_BASE_URL}/users/${id}`,
+        `${import.meta.env.VITE_API_BASE_URL}/users/me`,
         {
           headers: { Authorization: `Bearer ${token}` },
         }
@@ -54,6 +56,8 @@ export const useProvideAuth = () => {
       return {
         name: json.data?.name || '',
         avatar: json.data?.avatar || null,
+        isAdmin: !!json.data?.isAdmin,
+        isVerifiedStudent: !!json.data?.isVerifiedStudent,
       };
     } catch {
       return {};

--- a/frontend/src/Pages/AdminDashboard/AdminDashboard.css
+++ b/frontend/src/Pages/AdminDashboard/AdminDashboard.css
@@ -1,0 +1,144 @@
+.admin-page {
+  min-height: 100vh;
+  background: #080808;
+  padding-top: var(--nav-h, 72px);
+  color: #fff;
+}
+
+.admin-loading {
+  padding: 4rem 1.5rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.admin-back {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.7);
+  border-radius: 8px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+}
+
+.admin-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.admin-wrapper h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.admin-sub {
+  margin: 0.35rem 0 1.5rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.admin-empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.admin-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.admin-card-main h3 {
+  margin: 0 0 0.4rem;
+}
+
+.admin-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.82rem;
+}
+
+.admin-tag {
+  background: rgba(52, 211, 153, 0.12);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  color: #34d399;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+}
+
+.admin-desc {
+  margin: 0.6rem 0 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.admin-owner {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.admin-card-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.admin-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-width: 100px;
+}
+
+.admin-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.admin-btn--approve {
+  background: #16a34a;
+  color: #fff;
+}
+
+.admin-btn--reject {
+  background: transparent;
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  color: #f87171;
+}
+
+@media (max-width: 560px) {
+  .admin-card {
+    flex-direction: column;
+  }
+
+  .admin-card-actions {
+    flex-direction: row;
+    width: 100%;
+  }
+
+  .admin-btn {
+    flex: 1;
+  }
+}

--- a/frontend/src/Pages/AdminDashboard/AdminDashboard.jsx
+++ b/frontend/src/Pages/AdminDashboard/AdminDashboard.jsx
@@ -1,0 +1,143 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './AdminDashboard.css';
+import Navbar from '../../Components/Navbar/Navbar';
+import { useAuth } from '../../Hooks/UseAuth.ts';
+
+const API = import.meta.env.VITE_API_BASE_URL;
+
+export default function AdminDashboard() {
+  const navigate = useNavigate();
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
+
+  const [pending, setPending] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState(null);
+
+  const fetchPending = useCallback(async () => {
+    if (!user?.token) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API}/organizations/pending`, {
+        headers: { Authorization: `Bearer ${user.token}` },
+      });
+      const json = await res.json();
+      setPending(res.ok && json.success ? json.data : []);
+    } catch {
+      setPending([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAuthenticated || !user?.isAdmin) {
+      setLoading(false);
+      return;
+    }
+    fetchPending();
+  }, [authLoading, isAuthenticated, user, fetchPending]);
+
+  const review = async (id, action) => {
+    let reason = '';
+    if (action === 'reject') {
+      reason = window.prompt('Reason for rejection (optional):') || '';
+    }
+    setBusyId(id);
+    try {
+      const res = await fetch(`${API}/organizations/${id}/${action}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ reason }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        alert(json.message || 'Action failed');
+        return;
+      }
+      setPending((prev) => prev.filter((c) => c._id !== id));
+    } catch {
+      alert('Network error');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (authLoading || loading)
+    return <div className="admin-loading">Loading…</div>;
+
+  if (!isAuthenticated || !user?.isAdmin) {
+    return (
+      <div className="admin-page">
+        <Navbar page="/" />
+        <div className="admin-loading">
+          You don’t have access to this page.
+          <button className="admin-back" onClick={() => navigate('/')}>
+            ← Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="admin-page">
+      <Navbar page="/" />
+      <div className="admin-wrapper">
+        <h1>Club registrations</h1>
+        <p className="admin-sub">
+          {pending.length} pending review{pending.length !== 1 ? 's' : ''}
+        </p>
+
+        {pending.length === 0 ? (
+          <div className="admin-empty">Nothing waiting for review. 🎉</div>
+        ) : (
+          <div className="admin-list">
+            {pending.map((club) => (
+              <div key={club._id} className="admin-card">
+                <div className="admin-card-main">
+                  <h3>{club.name}</h3>
+                  <div className="admin-card-meta">
+                    {club.category && <span>{club.category}</span>}
+                    <span>{club.email}</span>
+                    {club.phoneNumber && <span>{club.phoneNumber}</span>}
+                    {club.studentOnly && (
+                      <span className="admin-tag">Students only</span>
+                    )}
+                  </div>
+                  {club.description && (
+                    <p className="admin-desc">{club.description}</p>
+                  )}
+                  {club.owner?.name && (
+                    <p className="admin-owner">
+                      Submitted by {club.owner.name}
+                      {club.owner.email ? ` (${club.owner.email})` : ''}
+                    </p>
+                  )}
+                </div>
+                <div className="admin-card-actions">
+                  <button
+                    className="admin-btn admin-btn--approve"
+                    disabled={busyId === club._id}
+                    onClick={() => review(club._id, 'approve')}>
+                    Approve
+                  </button>
+                  <button
+                    className="admin-btn admin-btn--reject"
+                    disabled={busyId === club._id}
+                    onClick={() => review(club._id, 'reject')}>
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Pages/Clubs/Clubs.css
+++ b/frontend/src/Pages/Clubs/Clubs.css
@@ -1,0 +1,187 @@
+.clubs-page {
+  min-height: 100vh;
+  background: #080808;
+  padding-top: var(--nav-h, 72px);
+  color: #fff;
+}
+
+.clubs-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.clubs-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.clubs-header h1 {
+  margin: 0;
+  font-size: 1.9rem;
+}
+
+.clubs-sub {
+  margin: 0.35rem 0 0;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.95rem;
+}
+
+.clubs-register-btn {
+  background: #7c3aed;
+  border: none;
+  color: #fff;
+  font-weight: 700;
+  padding: 0.6rem 1.1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s ease;
+}
+
+.clubs-register-btn:hover {
+  background: #6d28d9;
+}
+
+.clubs-search {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+}
+
+.clubs-search:focus {
+  outline: none;
+  border-color: rgba(124, 58, 237, 0.6);
+}
+
+.clubs-empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.clubs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+
+.club-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.club-card-top {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.club-logo {
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #a78bfa;
+  background: linear-gradient(145deg, #1a0533, #2e1065);
+  overflow: hidden;
+}
+
+.club-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.club-card-head h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.club-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.club-cat {
+  background: rgba(124, 58, 237, 0.12);
+  border: 1px solid rgba(124, 58, 237, 0.25);
+  color: #a78bfa;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+
+.club-desc {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.club-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+}
+
+.club-members {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.82rem;
+}
+
+.club-join-btn {
+  background: #7c3aed;
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.club-join-btn:hover {
+  background: #6d28d9;
+}
+
+.club-join-btn.is-member {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.club-join-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+@media (max-width: 560px) {
+  .clubs-register-btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/Pages/Clubs/Clubs.jsx
+++ b/frontend/src/Pages/Clubs/Clubs.jsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './Clubs.css';
+import Navbar from '../../Components/Navbar/Navbar';
+import { useAuth } from '../../Hooks/UseAuth.ts';
+import { useModal } from '../../Components/ModalContext.jsx';
+import RegisterClubModal from '../../Components/RegisterClubModal/RegisterClubModal';
+import VerifiedBadge from '../../Components/VerifiedBadge/VerifiedBadge';
+
+const API = import.meta.env.VITE_API_BASE_URL;
+
+export default function Clubs() {
+  const navigate = useNavigate();
+  const { user, isAuthenticated } = useAuth();
+  const { openSignIn } = useModal();
+
+  const [clubs, setClubs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+  const [showRegister, setShowRegister] = useState(false);
+  const [busyId, setBusyId] = useState(null);
+
+  const fetchClubs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API}/organizations/all`);
+      const json = await res.json();
+      setClubs(res.ok && json.success ? json.data : []);
+    } catch {
+      setClubs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchClubs();
+  }, [fetchClubs]);
+
+  const isMember = (club) =>
+    !!user?.id && (club.members || []).map(String).includes(String(user.id));
+
+  const toggleMembership = async (club) => {
+    if (!isAuthenticated || !user?.id) {
+      openSignIn();
+      return;
+    }
+    const joining = !isMember(club);
+    const route = joining ? 'add' : 'remove';
+    setBusyId(club._id);
+    try {
+      const res = await fetch(
+        `${API}/organizations/${club._id}/members/${route}/${user.id}`,
+        { method: 'PUT', headers: { Authorization: `Bearer ${user.token}` } }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        alert(json.message || 'Could not update membership');
+        return;
+      }
+      setClubs((prev) =>
+        prev.map((c) =>
+          c._id === club._id
+            ? {
+                ...c,
+                members: joining
+                  ? [...(c.members || []), user.id]
+                  : (c.members || []).filter(
+                      (m) => String(m) !== String(user.id)
+                    ),
+              }
+            : c
+        )
+      );
+    } catch {
+      alert('Network error updating membership');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const filtered = clubs.filter((c) => {
+    const q = query.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      c.name?.toLowerCase().includes(q) ||
+      c.category?.toLowerCase().includes(q) ||
+      c.description?.toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div className="clubs-page">
+      <Navbar page="/" />
+
+      <div className="clubs-wrapper">
+        <header className="clubs-header">
+          <div>
+            <h1>Clubs &amp; Organizations</h1>
+            <p className="clubs-sub">
+              Join a club to get its events surfaced first.
+            </p>
+          </div>
+          <button
+            className="clubs-register-btn"
+            onClick={() =>
+              isAuthenticated ? setShowRegister(true) : openSignIn()
+            }>
+            + Register your club
+          </button>
+        </header>
+
+        <input
+          className="clubs-search"
+          type="text"
+          placeholder="Search clubs by name, category…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+
+        {loading ? (
+          <div className="clubs-empty">Loading clubs…</div>
+        ) : filtered.length === 0 ? (
+          <div className="clubs-empty">
+            No clubs yet. Be the first to register one!
+          </div>
+        ) : (
+          <div className="clubs-grid">
+            {filtered.map((club) => {
+              const member = isMember(club);
+              return (
+                <div key={club._id} className="club-card">
+                  <div className="club-card-top">
+                    <div className="club-logo">
+                      {club.logo ? (
+                        <img src={club.logo} alt={club.name} />
+                      ) : (
+                        (club.name?.charAt(0) || '?').toUpperCase()
+                      )}
+                    </div>
+                    <div className="club-card-head">
+                      <h3>{club.name}</h3>
+                      <div className="club-meta">
+                        {club.category && (
+                          <span className="club-cat">{club.category}</span>
+                        )}
+                        {club.studentOnly && (
+                          <VerifiedBadge size="sm" label="Students only" />
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {club.description && (
+                    <p className="club-desc">{club.description}</p>
+                  )}
+
+                  <div className="club-card-footer">
+                    <span className="club-members">
+                      {(club.members || []).length} member
+                      {(club.members || []).length !== 1 ? 's' : ''}
+                    </span>
+                    <button
+                      className={`club-join-btn ${member ? 'is-member' : ''}`}
+                      disabled={busyId === club._id}
+                      onClick={() => toggleMembership(club)}>
+                      {busyId === club._id
+                        ? '…'
+                        : member
+                          ? 'Leave'
+                          : 'Join'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <RegisterClubModal
+        isOpen={showRegister}
+        onClose={() => setShowRegister(false)}
+        onSuccess={() => {
+          setShowRegister(false);
+          navigate('/profile');
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Frontend for the org subsystem shipped in #133.
- **`/clubs`** — browse approved clubs, search, join/leave. Sign-in prompt for guests; API errors (student-only, not-yet-approved) surfaced.
- **RegisterClubModal** — club registration form → `POST /organizations` (lands as pending review).
- **`/admin`** — admin-only dashboard listing pending registrations with approve/reject (reject prompts for a reason). Guarded by `user.isAdmin`.
- **Navbar** — "Clubs" link for everyone; "Admin" link only for admins.
- **Auth** — signed-in user now hydrated via `GET /users/me`, so the client knows `isAdmin` / `isVerifiedStudent`.

## Test plan
- `npm run build` ✅
- `jest unit-frontend` — 169 passed ✅
- Manual: register a club → appears in `/admin` → approve → shows in `/clubs` → join/leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)