### PR TITLE
Phase 4D: block users (profile + event hiding)

### DIFF
--- a/backend/EventFiles/EventRoutes.js
+++ b/backend/EventFiles/EventRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import eventServices from './EventServices.js';
+import userServices from '../UserFiles/UserServices.js';
 import { requireAuth, optionalAuth, requireSelf } from '../middleware/auth.js';
 
 const router = express.Router();
@@ -99,7 +100,15 @@ router.get('/nearby', optionalAuth, async (req, res) => {
   const maxDistance = Number.isNaN(radius) ? 16093 : radius; // ~10 miles default
 
   try {
-    const events = await eventServices.findNearbyEvents(lng, lat, maxDistance);
+    let events = await eventServices.findNearbyEvents(lng, lat, maxDistance);
+    // Hide events hosted by anyone who has blocked the viewer.
+    if (req.userId) {
+      const blockers = (
+        await userServices.findUserIdsWhoBlocked(req.userId)
+      ).map(String);
+      if (blockers.length)
+        events = events.filter((e) => !blockers.includes(String(e.host)));
+    }
     res.status(200).json({ success: true, data: events });
   } catch (error) {
     res.status(500).json({
@@ -110,27 +119,33 @@ router.get('/nearby', optionalAuth, async (req, res) => {
 });
 
 // Get event by ID
-router.get('/:id', async (req, res) => {
-  await eventServices
-    .findEventById(req.params.id)
-    .then((event) => {
-      if (!event)
-        res.status(404).json({
-          success: false,
-          message: 'Event not found',
-        });
-      else
-        res.status(200).json({
-          success: true,
-          data: event,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error}`,
-      });
-    });
+router.get('/:id', optionalAuth, async (req, res) => {
+  try {
+    const event = await eventServices.findEventById(req.params.id);
+    if (!event)
+      return res
+        .status(404)
+        .json({ success: false, message: 'Event not found' });
+
+    // A viewer blocked by the host can't see the event.
+    const hostId =
+      event.host && typeof event.host === 'object' ? event.host._id : event.host;
+    if (
+      req.userId &&
+      String(hostId) !== String(req.userId) &&
+      (await userServices.hasBlocked(hostId, req.userId))
+    ) {
+      return res
+        .status(404)
+        .json({ success: false, message: 'Event not found' });
+    }
+
+    res.status(200).json({ success: true, data: event });
+  } catch (error) {
+    res
+      .status(500)
+      .json({ success: false, message: `Error in the server: ${error}` });
+  }
 });
 
 // Create new event (auth required). Host is taken from the token, never the

--- a/backend/UserFiles/UserRoutes.js
+++ b/backend/UserFiles/UserRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import userServices from './UserServices.js';
 import jwt from 'jsonwebtoken';
-import { requireAuth, requireSelf } from '../middleware/auth.js';
+import { requireAuth, requireSelf, optionalAuth } from '../middleware/auth.js';
 import { authLimiter } from '../middleware/security.js';
 
 const router = express.Router();
@@ -253,28 +253,98 @@ router.get('/me', requireAuth, async (req, res) => {
 // projection-limited (no email/phone/dob/gender/location) — used by the public
 // profile page and event cards that show a host's name. For the logged-in
 // user's own full record, use GET /me (requireAuth).
-router.get('/:id', async (req, res) => {
-  await userServices
-    .findPublicProfileById(req.params.id)
-    .then((user) => {
-      if (!user)
-        res.status(404).json({
-          success: false,
-          message: 'User not found',
-        });
-      else
-        res.status(200).json({
-          success: true,
-          data: user,
-        });
-    })
-    .catch((error) => {
-      res.status(500).json({
-        success: false,
-        message: `Error in the server: ${error.message}`,
-      });
+router.get('/:id', optionalAuth, async (req, res) => {
+  try {
+    // A blocked viewer can't see the profile of someone who blocked them.
+    if (
+      req.userId &&
+      req.userId !== req.params.id &&
+      (await userServices.hasBlocked(req.params.id, req.userId))
+    ) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+
+    const user = await userServices.findPublicProfileById(req.params.id);
+    if (!user)
+      return res
+        .status(404)
+        .json({ success: false, message: 'User not found' });
+    res.status(200).json({ success: true, data: user });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: `Error in the server: ${error.message}`,
     });
+  }
 });
+
+// ── Block / unblock another user (self only) ──
+router.put(
+  '/:id/block/:targetId',
+  requireAuth,
+  requireSelf('id'),
+  async (req, res) => {
+    if (req.params.id === req.params.targetId)
+      return res
+        .status(400)
+        .json({ success: false, message: 'You cannot block yourself' });
+    try {
+      const updated = await userServices.blockUser(
+        req.params.id,
+        req.params.targetId
+      );
+      res.status(200).json({
+        success: true,
+        message: 'User blocked',
+        data: { blockedUsers: updated?.blockedUsers || [] },
+      });
+    } catch (error) {
+      res
+        .status(500)
+        .json({ success: false, message: `Error in the server: ${error}` });
+    }
+  }
+);
+
+router.put(
+  '/:id/unblock/:targetId',
+  requireAuth,
+  requireSelf('id'),
+  async (req, res) => {
+    try {
+      const updated = await userServices.unblockUser(
+        req.params.id,
+        req.params.targetId
+      );
+      res.status(200).json({
+        success: true,
+        message: 'User unblocked',
+        data: { blockedUsers: updated?.blockedUsers || [] },
+      });
+    } catch (error) {
+      res
+        .status(500)
+        .json({ success: false, message: `Error in the server: ${error}` });
+    }
+  }
+);
+
+// List the ids the current user has blocked.
+router.get(
+  '/:id/blocked',
+  requireAuth,
+  requireSelf('id'),
+  async (req, res) => {
+    try {
+      const blocked = await userServices.getBlockedUsers(req.params.id);
+      res.status(200).json({ success: true, data: blocked });
+    } catch (error) {
+      res
+        .status(500)
+        .json({ success: false, message: `Error in the server: ${error}` });
+    }
+  }
+);
 
 // Search users by name
 router.get('/search/name/:name', async (req, res) => {

--- a/backend/UserFiles/UserSchema.js
+++ b/backend/UserFiles/UserSchema.js
@@ -80,6 +80,12 @@ const UserSchema = new mongoose.Schema(
       type: [{ type: String }],
       required: false,
     },
+    // Users this account has blocked. A blocked user cannot see this account's
+    // profile or events.
+    blockedUsers: {
+      type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+      default: [],
+    },
     location: {
       type: {
         type: String,

--- a/backend/UserFiles/UserServices.js
+++ b/backend/UserFiles/UserServices.js
@@ -91,6 +91,7 @@ function updateUser(id, userData) {
     isAdmin,
     googleId,
     password,
+    blockedUsers,
     _id,
     ...safeData
   } = userData || {};
@@ -222,11 +223,58 @@ function findUserByAge(age) {
   });
 }
 
+// ── Blocking ──
+
+// Add targetId to blockerId's block list.
+function blockUser(blockerId, targetId) {
+  return userModel.findByIdAndUpdate(
+    blockerId,
+    { $addToSet: { blockedUsers: targetId } },
+    { new: true }
+  );
+}
+
+function unblockUser(blockerId, targetId) {
+  return userModel.findByIdAndUpdate(
+    blockerId,
+    { $pull: { blockedUsers: targetId } },
+    { new: true }
+  );
+}
+
+// Returns the blocker's block list (array of user ids).
+async function getBlockedUsers(blockerId) {
+  const user = await userModel.findById(blockerId).select('blockedUsers');
+  return user?.blockedUsers || [];
+}
+
+// True if `ownerId` has blocked `viewerId`.
+async function hasBlocked(ownerId, viewerId) {
+  if (!ownerId || !viewerId) return false;
+  const owner = await userModel.findById(ownerId).select('blockedUsers');
+  return (owner?.blockedUsers || []).some((b) => String(b) === String(viewerId));
+}
+
+// Returns the ids of all users who have blocked `viewerId` (so their content
+// can be filtered out of list/feed responses).
+async function findUserIdsWhoBlocked(viewerId) {
+  if (!viewerId) return [];
+  const users = await userModel
+    .find({ blockedUsers: viewerId })
+    .select('_id');
+  return users.map((u) => u._id);
+}
+
 export default {
   authenticateUser,
   getUsers,
   findUserById,
   findPublicProfileById,
+  blockUser,
+  unblockUser,
+  getBlockedUsers,
+  hasBlocked,
+  findUserIdsWhoBlocked,
   findUserByName,
   findUserByEmail,
   findUserByPhoneNumber,

--- a/frontend/src/Pages/PublicProfile/PublicProfile.css
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.css
@@ -196,3 +196,31 @@
   justify-content: center;
   margin: 0.1rem 0 0.4rem;
 }
+
+.pub-block-btn {
+  margin-top: 1.25rem;
+  width: 100%;
+  background: transparent;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #f87171;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: background 0.2s ease;
+}
+
+.pub-block-btn:hover {
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.pub-block-btn.is-blocked {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.pub-block-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/frontend/src/Pages/PublicProfile/PublicProfile.jsx
+++ b/frontend/src/Pages/PublicProfile/PublicProfile.jsx
@@ -15,6 +15,10 @@ export default function PublicProfile() {
   const [hostedEvents, setHostedEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState('');
+  const [isBlocked, setIsBlocked] = useState(false);
+  const [blockBusy, setBlockBusy] = useState(false);
+
+  const isOwnProfile = user?.id === id;
 
   // If the viewer lands on their own public profile, send them to the editable one.
   useEffect(() => {
@@ -29,7 +33,10 @@ export default function PublicProfile() {
       setErrorMsg('');
       try {
         const res = await fetch(
-          `${import.meta.env.VITE_API_BASE_URL}/users/${id}`
+          `${import.meta.env.VITE_API_BASE_URL}/users/${id}`,
+          user?.token
+            ? { headers: { Authorization: `Bearer ${user.token}` } }
+            : undefined
         );
         const json = await res.json();
         if (!res.ok || !json.success)
@@ -39,6 +46,21 @@ export default function PublicProfile() {
         if (!cancelled) setErrorMsg(err.message);
       } finally {
         if (!cancelled) setLoading(false);
+      }
+    };
+
+    const fetchBlockStatus = async () => {
+      if (!user?.id || user.id === id) return;
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_API_BASE_URL}/users/${user.id}/blocked`,
+          { headers: { Authorization: `Bearer ${user.token}` } }
+        );
+        const json = await res.json();
+        if (!cancelled && res.ok && json.success)
+          setIsBlocked(json.data.map(String).includes(String(id)));
+      } catch {
+        /* ignore */
       }
     };
 
@@ -56,10 +78,33 @@ export default function PublicProfile() {
 
     fetchProfile();
     fetchHosted();
+    fetchBlockStatus();
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, user?.id, user?.token]);
+
+  const toggleBlock = async () => {
+    if (!user?.id || isOwnProfile) return;
+    const action = isBlocked ? 'unblock' : 'block';
+    setBlockBusy(true);
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/users/${user.id}/${action}/${id}`,
+        { method: 'PUT', headers: { Authorization: `Bearer ${user.token}` } }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        alert(json.message || 'Could not update block status');
+        return;
+      }
+      setIsBlocked(!isBlocked);
+    } catch {
+      alert('Network error');
+    } finally {
+      setBlockBusy(false);
+    }
+  };
 
   const renderEventCard = (event) => (
     <EventComponent
@@ -138,6 +183,19 @@ export default function PublicProfile() {
                   {interests.length !== 1 ? 's' : ''}
                 </span>
               </div>
+            )}
+
+            {user?.id && !isOwnProfile && (
+              <button
+                className={`pub-block-btn ${isBlocked ? 'is-blocked' : ''}`}
+                onClick={toggleBlock}
+                disabled={blockBusy}>
+                {blockBusy
+                  ? '…'
+                  : isBlocked
+                    ? 'Unblock'
+                    : 'Block user'}
+              </button>
             )}
           </div>
         </aside>

--- a/tests/Integration/Users/user.block.test.js
+++ b/tests/Integration/Users/user.block.test.js
@@ -1,0 +1,92 @@
+import request from 'supertest';
+import app from '../../../backend/backend.js';
+import userModel from '../../../backend/UserFiles/UserSchema.js';
+import mongoose from 'mongoose';
+import { authHeader } from '../../helpers/auth.js';
+
+beforeEach(async () => {
+  await userModel.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+async function makeUser(email) {
+  return userModel.create({ name: email.split('@')[0], email });
+}
+
+describe('User blocking', () => {
+  test('block then unblock updates the block list', async () => {
+    const blocker = await makeUser('blocker@example.com');
+    const target = await makeUser('target@example.com');
+
+    const blockRes = await request(app)
+      .put(`/users/${blocker._id}/block/${target._id}`)
+      .set(authHeader(blocker._id));
+    expect(blockRes.status).toBe(200);
+    expect(blockRes.body.data.blockedUsers.map(String)).toContain(
+      String(target._id)
+    );
+
+    const unblockRes = await request(app)
+      .put(`/users/${blocker._id}/unblock/${target._id}`)
+      .set(authHeader(blocker._id));
+    expect(unblockRes.status).toBe(200);
+    expect(unblockRes.body.data.blockedUsers.map(String)).not.toContain(
+      String(target._id)
+    );
+  });
+
+  test('cannot block on behalf of another user', async () => {
+    const a = await makeUser('a@example.com');
+    const b = await makeUser('b@example.com');
+    const res = await request(app)
+      .put(`/users/${a._id}/block/${b._id}`)
+      .set(authHeader(b._id)); // wrong identity
+    expect(res.status).toBe(403);
+  });
+
+  test('cannot block yourself', async () => {
+    const a = await makeUser('self@example.com');
+    const res = await request(app)
+      .put(`/users/${a._id}/block/${a._id}`)
+      .set(authHeader(a._id));
+    expect(res.status).toBe(400);
+  });
+
+  test('a blocked viewer gets 404 on the blocker profile', async () => {
+    const blocker = await makeUser('owner@example.com');
+    const blocked = await makeUser('blocked@example.com');
+    await userModel.findByIdAndUpdate(blocker._id, {
+      $addToSet: { blockedUsers: blocked._id },
+    });
+
+    const res = await request(app)
+      .get(`/users/${blocker._id}`)
+      .set(authHeader(blocked._id));
+    expect(res.status).toBe(404);
+  });
+
+  test('an unrelated viewer can still see the profile', async () => {
+    const blocker = await makeUser('owner2@example.com');
+    const other = await makeUser('other@example.com');
+    const res = await request(app)
+      .get(`/users/${blocker._id}`)
+      .set(authHeader(other._id));
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /users/:id/blocked is self-only', async () => {
+    const a = await makeUser('listowner@example.com');
+    const b = await makeUser('intruder@example.com');
+    const ok = await request(app)
+      .get(`/users/${a._id}/blocked`)
+      .set(authHeader(a._id));
+    expect(ok.status).toBe(200);
+    const forbidden = await request(app)
+      .get(`/users/${a._id}/blocked`)
+      .set(authHeader(b._id));
+    expect(forbidden.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- `User.blockedUsers` (ref User), stripped from generic profile updates.
- **Self-only** routes: `PUT /users/:id/block|unblock/:targetId`, `GET /users/:id/blocked`; can't block yourself.
- **Enforcement** (optionalAuth, viewer-aware):
  - `GET /users/:id` → 404 if the target blocked the viewer.
  - `GET /events/:id` → 404 if the host blocked the viewer.
  - `GET /events/nearby` → filters out events from hosts who blocked the viewer.
- **Frontend:** Block/Unblock button on public profiles; profile fetch now sends the viewer's token so block checks apply.

## Test plan
- New `user.block.test.js` integration suite (block list, self-only guards, profile hiding).
- `node --check` backend ✅, `npm run build` ✅, `jest unit-frontend` 169 ✅. Integration runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)