### PR TITLE
Fix Google sign-in duplicate-email crash + real student verification

### DIFF
--- a/backend/OAuth/GoogleAuthRoutes.js
+++ b/backend/OAuth/GoogleAuthRoutes.js
@@ -38,30 +38,39 @@ passport.use(
     async (accessToken, refreshToken, profile, done) => {
       console.log('Google profile:', profile);
       try {
-        const email = profile.emails?.[0]?.value;
+        const email = profile.emails?.[0]?.value?.toLowerCase();
+        // Google has authenticated this email, so a student domain here is a
+        // genuine "verified student" signal (Cal Poly accounts are Google
+        // Workspace accounts) — unlike a self-typed email at password signup.
         const verifiedStudent = isStudentEmail(email);
         const admin = isAdminEmail(email);
 
         let user = await User.findOne({ googleId: profile.id });
 
+        // Not found by googleId — link to an existing email/password account
+        // with the same email instead of creating a duplicate (which would hit
+        // the unique-email index and throw E11000).
+        if (!user && email) {
+          user = await User.findOne({ email });
+        }
+
         if (!user) {
-          user = await User.create({
+          user = new User({
             googleId: profile.id,
             email,
             name: profile.displayName,
             avatar: profile.photos?.[0]?.value,
-            isVerifiedStudent: verifiedStudent,
-            isAdmin: admin,
           });
-        } else if (
-          user.isVerifiedStudent !== verifiedStudent ||
-          user.isAdmin !== admin
-        ) {
-          // Keep badge / admin status in sync with the configured lists.
-          user.isVerifiedStudent = verifiedStudent;
-          user.isAdmin = admin;
-          await user.save();
+        } else if (!user.googleId) {
+          // Link Google to the existing account.
+          user.googleId = profile.id;
+          if (!user.avatar) user.avatar = profile.photos?.[0]?.value;
         }
+
+        // Sync server-controlled flags every login.
+        user.isVerifiedStudent = verifiedStudent;
+        user.isAdmin = admin;
+        await user.save();
 
         return done(null, user);
       } catch (err) {
@@ -91,15 +100,26 @@ router.get(
   passport.authenticate('google', { scope: ['profile', 'email'] })
 );
 
-// OAuth callback
-router.get(
-  '/google/callback',
-  passport.authenticate('google', { failureRedirect: '/' }),
-  (req, res) => {
+// OAuth callback — custom handler so any failure redirects back to the SPA
+// with a friendly ?authError= message instead of dumping raw JSON.
+router.get('/google/callback', (req, res, next) => {
+  const frontendBase =
+    process.env.NODE_ENV === 'production'
+      ? process.env.FRONTEND_URL
+      : 'http://localhost:5173';
+
+  passport.authenticate('google', (err, user) => {
+    if (err || !user) {
+      const msg = encodeURIComponent(
+        'Google sign-in failed. Please try again.'
+      );
+      return res.redirect(`${frontendBase}/?authError=${msg}`);
+    }
+
     // Issue the SAME tokens as standard email/password auth so the whole
     // app runs on one JWT model (no longer relying on the passport session
     // for app auth).
-    const userId = req.user._id;
+    const userId = user._id;
 
     const accessToken = jwt.sign({ id: userId }, process.env.JWT_TOKEN_SECRET, {
       expiresIn: '15m',
@@ -121,14 +141,9 @@ router.get(
 
     // Redirect to the SPA carrying the access token in the URL hash so the
     // frontend can store it and populate auth state.
-    const frontendBase =
-      process.env.NODE_ENV === 'production'
-        ? process.env.FRONTEND_URL
-        : 'http://localhost:5173';
-
     res.redirect(`${frontendBase}/#token=${accessToken}&userId=${userId}`);
-  }
-);
+  })(req, res, next);
+});
 
 // Who am I (frontend uses this)
 router.get('/me', (req, res) => {

--- a/backend/UserFiles/UserServices.js
+++ b/backend/UserFiles/UserServices.js
@@ -1,7 +1,6 @@
 import userModel from './UserSchema.js';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
-import { isStudentEmail } from '../utils/studentEmail.js';
 import { isAdminEmail } from '../utils/adminEmail.js';
 
 /*
@@ -27,12 +26,11 @@ async function authenticateUser(email, password) {
   const isValid = await comparePassword(user, password);
   if (!isValid) return null;
 
-  // Keep the verified-student badge in sync for accounts created before the
-  // field existed (or if the domain list changed).
-  const verifiedStudent = isStudentEmail(user.email);
+  // Keep admin status in sync (config-driven). Verified-student is intentionally
+  // NOT changed here — it's only granted via Google-authenticated student
+  // accounts, and a password login shouldn't revoke a previously verified badge.
   const admin = isAdminEmail(user.email);
-  if (user.isVerifiedStudent !== verifiedStudent || user.isAdmin !== admin) {
-    user.isVerifiedStudent = verifiedStudent;
+  if (user.isAdmin !== admin) {
     user.isAdmin = admin;
     await user.save();
   }
@@ -70,9 +68,10 @@ async function addUser(user) {
     throw error;
   }
   const formatteduser = formatUser(user);
-  // Derive verified-student status from the email domain — never trust a
-  // client-supplied flag.
-  formatteduser.isVerifiedStudent = isStudentEmail(user.email);
+  // Verified-student status is NOT granted from a self-typed email at password
+  // signup (anyone could type @calpoly.edu). It's only granted when Google has
+  // actually authenticated a student-domain account (see GoogleAuthRoutes).
+  formatteduser.isVerifiedStudent = false;
   formatteduser.isAdmin = isAdminEmail(user.email);
   const newUser = new userModel(formatteduser);
   return await newUser.save();

--- a/frontend/src/Components/ModalContext.jsx
+++ b/frontend/src/Components/ModalContext.jsx
@@ -1,27 +1,54 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 const ModalContext = createContext(null);
 
 export function ModalProvider({ children }) {
   const [showSignIn, setShowSignIn] = useState(false);
   const [showRegister, setShowRegister] = useState(false);
+  const [signInError, setSignInError] = useState('');
 
-  const openSignIn = () => {
+  const openSignIn = (message = '') => {
+    setSignInError(typeof message === 'string' ? message : '');
     setShowRegister(false);
     setShowSignIn(true);
   };
   const openRegister = () => {
+    setSignInError('');
     setShowSignIn(false);
     setShowRegister(true);
   };
   const closeAll = () => {
+    setSignInError('');
     setShowSignIn(false);
     setShowRegister(false);
   };
 
+  // Surface OAuth failures redirected back as ?authError=… by opening the
+  // sign-in modal with the message, then cleaning the URL.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const authError = params.get('authError');
+    if (authError) {
+      openSignIn(authError);
+      params.delete('authError');
+      const qs = params.toString();
+      const newUrl =
+        window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+      window.history.replaceState({}, '', newUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <ModalContext.Provider
-      value={{ showSignIn, showRegister, openSignIn, openRegister, closeAll }}>
+      value={{
+        showSignIn,
+        showRegister,
+        signInError,
+        openSignIn,
+        openRegister,
+        closeAll,
+      }}>
       {children}
     </ModalContext.Provider>
   );

--- a/frontend/src/Components/ModalContext.jsx
+++ b/frontend/src/Components/ModalContext.jsx
@@ -36,7 +36,6 @@ export function ModalProvider({ children }) {
         window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
       window.history.replaceState({}, '', newUrl);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../Hooks/UseAuth.ts';
+import { useModal } from '../../ModalContext.jsx';
 import './SignInModal.css';
 
 export default function SignInModal({ isOpen, onClose, onSwitchToRegister }) {
@@ -9,7 +10,13 @@ export default function SignInModal({ isOpen, onClose, onSwitchToRegister }) {
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
   const { login, loginWithGoogle } = useAuth();
+  const signInError = useModal()?.signInError || '';
   const navigate = useNavigate();
+
+  // Seed the error from an OAuth redirect (e.g. ?authError=) when opening.
+  useEffect(() => {
+    if (isOpen && signInError) setErrorMsg(signInError);
+  }, [isOpen, signInError]);
 
   // Close on Escape key
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes the `E11000 duplicate key … email` crash when signing in with Google using an email that already has an account.

**Root cause:** the Google OAuth flow only looked up accounts by `googleId`. If you'd previously registered with email/password, it tried to *create a second account* with the same email → unique-index violation → raw JSON error.

**Fixes:**
- Google OAuth **links** to the existing account by email (sets `googleId`) instead of duplicating.
- OAuth failures now redirect to the SPA with `?authError=…`, shown as a **friendly warning in the sign-in modal** (no more raw JSON).
- **Verified-student badge** is now only granted via a Google-authenticated student-domain account (real proof, since Cal Poly accounts are Google Workspace accounts). A self-typed `@calpoly.edu` at password signup no longer grants it.

## Test plan
- `node --check` backend ✅, `npm run build` ✅, `jest unit-frontend` 169 ✅
- Manual: Google sign-in with an email that already has a password account → links & logs in (no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)