### PR TITLE
fix: mobile UI overhaul + auth persistence

### DIFF
--- a/frontend/src/Components/CreateEventModal/CreateEventModal.css
+++ b/frontend/src/Components/CreateEventModal/CreateEventModal.css
@@ -463,6 +463,58 @@ button.secondary:hover {
   color: #c4b5fd;
 }
 
+/* --- Mobile: bottom-sheet modal --- */
+@media (max-width: 520px) {
+  .modal-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .modal {
+    width: 100%;
+    max-width: 100%;
+    max-height: 92dvh;
+    border-radius: 20px 20px 0 0;
+    animation: modal-slide-up 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes modal-slide-up {
+    from {
+      opacity: 0;
+      transform: translateY(40px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .modal-header {
+    padding: 1rem 1.25rem 0.9rem;
+  }
+
+  .modal-body {
+    padding: 1.1rem 1.25rem;
+  }
+
+  .modal-actions {
+    padding: 0.9rem 1.25rem 1.25rem;
+    flex-direction: column-reverse;
+    gap: 0.6rem;
+  }
+
+  .modal-actions button {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .datetime-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+}
+
 /* --- Custom interests multi-select --- */
 .cem-ms {
   position: relative;

--- a/frontend/src/Components/EventColumn/EventColumn.css
+++ b/frontend/src/Components/EventColumn/EventColumn.css
@@ -62,6 +62,21 @@
   .Event_Container {
     top: 0;
     height: 100%;
-    padding-top: 16px;
+    padding-top: 28px;
+  }
+
+  /* Visual drag handle pill above content */
+  .Event_Container::before {
+    content: '';
+    display: block;
+    width: 40px;
+    height: 4px;
+    background: rgba(0, 0, 0, 0.18);
+    border-radius: 2px;
+    margin: 0 auto 12px;
+  }
+
+  .Search_Bar {
+    border-radius: 10px;
   }
 }

--- a/frontend/src/Components/EventColumn/EventColumn.css
+++ b/frontend/src/Components/EventColumn/EventColumn.css
@@ -62,18 +62,7 @@
   .Event_Container {
     top: 0;
     height: 100%;
-    padding-top: 28px;
-  }
-
-  /* Visual drag handle pill above content */
-  .Event_Container::before {
-    content: '';
-    display: block;
-    width: 40px;
-    height: 4px;
-    background: rgba(0, 0, 0, 0.18);
-    border-radius: 2px;
-    margin: 0 auto 12px;
+    padding-top: 32px;
   }
 
   .Search_Bar {

--- a/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
+++ b/frontend/src/Components/Modals/RegistrationModal/RegistrationModal.css
@@ -371,11 +371,36 @@
 
 /* ── Mobile ── */
 @media (max-width: 560px) {
+  .rmodal__overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+
   .rmodal__card {
-    padding: 1.75rem 1.25rem 1.5rem;
+    max-width: 100%;
+    border-radius: 20px 20px 0 0;
+    padding: 1.5rem 1.25rem 2rem;
+    max-height: 92dvh;
+    animation: rcard-slide-up 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes rcard-slide-up {
+    from {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   .rmodal__grid {
     grid-template-columns: 1fr;
+  }
+
+  .rmodal__submit {
+    padding: 0.85rem;
+    font-size: 1rem;
   }
 }

--- a/frontend/src/Components/Modals/SignInModal/SignInModal.css
+++ b/frontend/src/Components/Modals/SignInModal/SignInModal.css
@@ -36,8 +36,34 @@
 }
 
 @media (max-width: 480px) {
+  .modal__overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+
   .modal__card {
-    padding: 1.75rem 1.25rem 1.5rem;
+    max-width: 100%;
+    border-radius: 20px 20px 0 0;
+    padding: 1.5rem 1.25rem 2rem;
+    max-height: 92dvh;
+    animation: card-slide-up 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes card-slide-up {
+    from {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .modal__submit,
+  .modal__google {
+    padding: 0.85rem;
+    font-size: 1rem;
   }
 }
 

--- a/frontend/src/Components/Navbar/Navbar.css
+++ b/frontend/src/Components/Navbar/Navbar.css
@@ -251,70 +251,163 @@ body {
   border-bottom: 1px solid rgba(124, 58, 237, 0.5);
 }
 
+/* ── Hamburger button (mobile only) ── */
 .navbar__hamburger {
   display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  transition: background 0.2s;
 }
 
-/* ── Tablet ── */
+.navbar__hamburger:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.navbar__hamburger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #fff;
+  border-radius: 2px;
+  transition:
+    transform 0.25s ease,
+    opacity 0.2s ease;
+  transform-origin: center;
+}
+
+.navbar__hamburger.is-open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.navbar__hamburger.is-open span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+
+.navbar__hamburger.is-open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* ── Mobile slide-down menu ── */
+.navbar__mobile-menu {
+  position: fixed;
+  top: var(--nav-h);
+  left: 0;
+  right: 0;
+  background: #000000;
+  border-bottom: 1px solid rgba(124, 58, 237, 0.2);
+  padding: 0.75rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  z-index: 999;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  animation: nmm-slide-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes nmm-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.nmm-link {
+  display: block;
+  padding: 0.8rem 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  font-family: 'Consolas', 'Courier New', monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 8px;
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.nmm-link:hover {
+  color: #fff;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.nmm-link.active {
+  color: #a78bfa;
+}
+
+.nmm-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 0.5rem 0;
+}
+
+.nmm-btn {
+  display: block;
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.2s;
+  margin-top: 0.2rem;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+}
+
+.nmm-btn--ghost {
+  background: transparent;
+  border: 1.5px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.nmm-btn--ghost:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+  color: #fff;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nmm-btn--primary {
+  background: #7c3aed;
+  border: none;
+  color: #fff;
+  box-shadow: 0 4px 18px rgba(124, 58, 237, 0.35);
+}
+
+.nmm-btn--primary:hover {
+  background: #6d28d9;
+}
+
+/* ── Tablet — switch to hamburger ── */
 @media (max-width: 768px) {
   .navbar {
     padding: 0 1.25rem;
   }
-}
 
-/* ── Mobile ── */
-@media (max-width: 560px) {
-  .navbar {
-    padding: 0 0.85rem;
-    gap: 0.5rem;
-  }
-
-  /* Pull the centered Explore link back into normal flow so it can't overlap
-     the logo or the auth buttons on narrow screens. */
-  .navbar__explore {
-    position: static;
-    left: auto;
-    transform: none;
-    flex: 1;
-    justify-content: center;
-    gap: 0.9rem;
-  }
-
-  .navbar__logo h2 {
-    font-size: 1.15rem;
-    letter-spacing: 1px;
-  }
-
-  .navbar__explore-link {
-    font-size: 0.78rem;
-    letter-spacing: 0.05em;
-  }
-
+  .navbar__explore,
   .navbar__links {
-    gap: 0.4rem;
+    display: none;
   }
 
-  .navbar__link.signin,
-  .navbar__link.signup,
-  .navbar__logout-btn {
-    padding: 0.35rem 0.7rem;
-    font-size: 0.78rem;
-  }
-
-  .navbar__profile {
-    gap: 0.5rem;
-  }
-
-  .navbar__profile-icon,
-  .navbar__profile-initial {
-    width: 32px;
-    height: 32px;
-  }
-}
-
-/* ── Very small phones ── */
-@media (max-width: 380px) {
-  .navbar__link.signin {
-    display: none; /* keep the primary "Registration" CTA, drop secondary */
+  .navbar__hamburger {
+    display: flex;
   }
 }

--- a/frontend/src/Components/Navbar/Navbar.jsx
+++ b/frontend/src/Components/Navbar/Navbar.jsx
@@ -1,4 +1,5 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
+import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../../Hooks/UseAuth.ts';
 import { useModal } from '../ModalContext.jsx';
 import './Navbar.css';
@@ -6,15 +7,39 @@ import './Navbar.css';
 export default function Navbar({ page = '/' }) {
   const { isAuthenticated, logout, user } = useAuth();
   const { openSignIn, openRegister } = useModal();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navRef = useRef(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e) => {
+      if (navRef.current && !navRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
+  }, [menuOpen]);
 
   const linkClass = ({ isActive }) =>
     isActive ? 'navbar__link active' : 'navbar__link';
 
+  const closeMenu = () => setMenuOpen(false);
+
   return (
-    <nav className="navbar">
+    <nav className="navbar" ref={navRef}>
       <div className="navbar__logo">
         <NavLink to={page} className={linkClass} end>
-          <h2>Findr</h2>
+          <h2>Findr<span>.</span></h2>
         </NavLink>
       </div>
 
@@ -84,6 +109,72 @@ export default function Navbar({ page = '/' }) {
           </div>
         )}
       </div>
+
+      {/* Hamburger — mobile only */}
+      <button
+        className={`navbar__hamburger${menuOpen ? ' is-open' : ''}`}
+        onClick={() => setMenuOpen((o) => !o)}
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}>
+        <span />
+        <span />
+        <span />
+      </button>
+
+      {/* Mobile slide-down menu */}
+      {menuOpen && (
+        <div className="navbar__mobile-menu">
+          <NavLink
+            to="/home"
+            className={({ isActive }) => (isActive ? 'nmm-link active' : 'nmm-link')}
+            onClick={closeMenu}>
+            Explore
+          </NavLink>
+          <NavLink
+            to="/clubs"
+            className={({ isActive }) => (isActive ? 'nmm-link active' : 'nmm-link')}
+            onClick={closeMenu}>
+            Clubs
+          </NavLink>
+          <div className="nmm-divider" />
+          {!isAuthenticated ? (
+            <>
+              <button
+                className="nmm-btn nmm-btn--ghost"
+                onClick={() => { closeMenu(); openSignIn(); }}>
+                Sign In
+              </button>
+              <button
+                className="nmm-btn nmm-btn--primary"
+                onClick={() => { closeMenu(); openRegister(); }}>
+                Register
+              </button>
+            </>
+          ) : (
+            <>
+              {user?.isAdmin && (
+                <NavLink
+                  to="/admin"
+                  className={({ isActive }) => (isActive ? 'nmm-link active' : 'nmm-link')}
+                  onClick={closeMenu}>
+                  Admin
+                </NavLink>
+              )}
+              <NavLink
+                to="/profile"
+                className={({ isActive }) => (isActive ? 'nmm-link active' : 'nmm-link')}
+                onClick={closeMenu}>
+                Profile
+              </NavLink>
+              <button
+                className="nmm-btn nmm-btn--ghost"
+                onClick={() => { closeMenu(); logout(); }}>
+                Logout
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </nav>
   );
 }

--- a/frontend/src/Hooks/UseAuth.ts
+++ b/frontend/src/Hooks/UseAuth.ts
@@ -33,6 +33,43 @@ export const useAuth = () => {
   return context;
 };
 
+// ── localStorage session persistence ──
+// Access tokens expire in 15 min on the server; we store them for 14 min so
+// we always have a chance to refresh before an API call fails.
+const SESSION_KEY = 'findr_session';
+const TOKEN_EXPIRY_MS = 14 * 60 * 1000;
+
+function saveSession(id: string, token: string) {
+  try {
+    localStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ id, token, expiresAt: Date.now() + TOKEN_EXPIRY_MS })
+    );
+  } catch {}
+}
+
+function clearSession() {
+  try {
+    localStorage.removeItem(SESSION_KEY);
+    localStorage.removeItem('userToken');
+    localStorage.removeItem('userId');
+    sessionStorage.clear();
+  } catch {}
+}
+
+function loadSession(): { id: string; token: string } | null {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed?.token || !parsed?.id) return null;
+    if (parsed.expiresAt && parsed.expiresAt <= Date.now()) return null;
+    return { id: parsed.id, token: parsed.token };
+  } catch {
+    return null;
+  }
+}
+
 export const useProvideAuth = () => {
   const [user, setUser] = useState<UserState | null>(null);
   const [error, setError] = useState<string>('');
@@ -65,9 +102,6 @@ export const useProvideAuth = () => {
   };
 
   // ── Helper: consume an access token handed back via the URL hash ──
-  // Google OAuth redirects to `/#token=<jwt>&userId=<id>`. When present we
-  // adopt that token (same JWT model as email/password login), fetch the
-  // user profile, clean the hash, and land on /home.
   const consumeHashToken = async (): Promise<boolean> => {
     const hash = window.location.hash;
     if (!hash || !hash.includes('token=')) return false;
@@ -91,24 +125,52 @@ export const useProvideAuth = () => {
             }))
             .catch(() => ({}))
         : {};
+      saveSession(userId, token);
       setUser({ id: userId, token, ...profile });
     } catch {
       setUser({ id: userId, token });
     }
 
-    // Strip the token from the URL so it isn't left in history/bookmarks.
     history.replaceState(null, '', window.location.pathname + window.location.search);
     navigate('/home');
     return true;
   };
 
-  // Check session: first try a Google OAuth hash token, then fall back to the
-  // refresh token (HttpOnly cookie).
+  // ── Silently try cookie-based refresh; update localStorage if it succeeds ──
+  const tryRefreshInBackground = () => {
+    fetch(`${import.meta.env.VITE_API_BASE_URL}/users/refresh-token`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.accessToken && data?.userId) {
+          saveSession(data.userId, data.accessToken);
+          setUser((prev) =>
+            prev ? { ...prev, id: data.userId, token: data.accessToken } : prev
+          );
+        }
+      })
+      .catch(() => {});
+  };
+
   useEffect(() => {
     const checkSession = async () => {
       try {
         if (await consumeHashToken()) return;
 
+        // 1. Try localStorage first — instant restoration, no network needed.
+        const stored = loadSession();
+        if (stored) {
+          const profile = await fetchUserProfile(stored.id, stored.token);
+          setUser({ id: stored.id, token: stored.token, ...profile });
+          setLoading(false);
+          // Kick off a background refresh to extend the cookie session.
+          tryRefreshInBackground();
+          return;
+        }
+
+        // 2. No valid localStorage entry — fall back to cookie-based refresh.
         const res = await fetch(
           `${import.meta.env.VITE_API_BASE_URL}/users/refresh-token`,
           { method: 'POST', credentials: 'include' }
@@ -119,6 +181,7 @@ export const useProvideAuth = () => {
         } else {
           const data = await res.json();
           const profile = await fetchUserProfile(data.userId, data.accessToken);
+          saveSession(data.userId, data.accessToken);
           setUser({ id: data.userId, token: data.accessToken, ...profile });
         }
       } catch {
@@ -156,6 +219,7 @@ export const useProvideAuth = () => {
     const data = await res.json();
     const profile = await fetchUserProfile(data.userId, data.accessToken);
     const newUser = { id: data.userId, token: data.accessToken, ...profile };
+    saveSession(data.userId, data.accessToken);
     setUser(newUser);
     return newUser;
   };
@@ -183,6 +247,7 @@ export const useProvideAuth = () => {
       const id = data.userId || data.user?._id;
       const token = data.token || data.accessToken;
       const profile = await fetchUserProfile(id, token);
+      saveSession(id, token);
       setUser({ id, token, ...profile });
       return data;
     } catch (err: any) {
@@ -202,10 +267,8 @@ export const useProvideAuth = () => {
     } catch (err) {
       console.error('Logout failed', err);
     }
+    clearSession();
     setUser(null);
-    localStorage.removeItem('userToken');
-    localStorage.removeItem('userId');
-    sessionStorage.clear();
     navigate('/');
   };
 

--- a/frontend/src/Pages/Clubs/Clubs.css
+++ b/frontend/src/Pages/Clubs/Clubs.css
@@ -184,8 +184,32 @@
   cursor: default;
 }
 
-@media (max-width: 560px) {
+@media (max-width: 640px) {
+  .clubs-wrapper {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .clubs-header {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .clubs-header h1 {
+    font-size: 1.55rem;
+  }
+
   .clubs-register-btn {
     width: 100%;
+    padding: 0.7rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .clubs-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .club-card {
+    padding: 1rem;
   }
 }

--- a/frontend/src/Pages/EventDetails/EventDetails.css
+++ b/frontend/src/Pages/EventDetails/EventDetails.css
@@ -641,6 +641,48 @@
   }
 }
 
+@media (max-width: 400px) {
+  .ed-wrapper {
+    padding: calc(var(--nav-h) + 12px) 0.75rem 3rem;
+  }
+
+  .ed-header {
+    padding: 1.1rem 1rem;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .ed-avatar {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    font-size: 1.2rem;
+  }
+
+  .ed-title {
+    font-size: 1.2rem;
+  }
+
+  .ed-body {
+    padding: 1rem;
+  }
+
+  .ed-actions,
+  .ed-comments {
+    padding: 1rem;
+  }
+
+  .ed-actions-row {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .ed-confirm-card {
+    padding: 1.5rem 1rem;
+    margin: 0 0.75rem;
+  }
+}
+
 /* ── Confirm modal ── */
 .ed-confirm-backdrop {
   position: fixed;

--- a/frontend/src/Pages/Explore/Explore.css
+++ b/frontend/src/Pages/Explore/Explore.css
@@ -1,5 +1,6 @@
 .explore-page {
   min-height: 100vh;
+  padding-top: var(--nav-h, 80px);
 }
 
 .explore-hero {
@@ -140,5 +141,43 @@
   }
   .explore-filters {
     position: static;
+  }
+}
+
+@media (max-width: 600px) {
+  .explore-hero {
+    padding: 1.25rem 0 0.75rem;
+  }
+
+  .explore-hero h1 {
+    font-size: 1.6rem;
+  }
+
+  .explore-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
+  }
+
+  .explore-search {
+    flex: none;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+  }
+
+  .explore-sort,
+  .explore-nearme {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.65rem 1rem;
+    font-size: 0.95rem;
+    justify-content: center;
+  }
+
+  .explore-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
   }
 }

--- a/frontend/src/Pages/Home/HomePage.css
+++ b/frontend/src/Pages/Home/HomePage.css
@@ -127,6 +127,11 @@ body:has(.HomePage) {
   transform: translateX(0);
 }
 
+/* "Events" label — hidden on desktop (button is icon-only), shown on mobile */
+.col-open-label {
+  display: none;
+}
+
 /* ── Create Event button shifts left when column closes ── */
 .Create-Event-Button {
   position: absolute;
@@ -168,24 +173,38 @@ body:has(.HomePage) {
 
   /* Close affordance: pill drag handle at top-center */
   .col-close-btn {
-    top: 10px;
+    top: 0;
     right: 50%;
     transform: translate(50%, 0);
-    width: 44px;
-    height: 5px;
-    border-radius: 3px;
-    background: rgba(0, 0, 0, 0.2);
+    width: 64px;
+    height: 28px;
+    border-radius: 0 0 8px 8px;
+    background: transparent;
     border: none;
     box-shadow: none;
     backdrop-filter: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* The visible pill is a ::before pseudo so the tap area stays large */
+  .col-close-btn::before {
+    content: '';
+    display: block;
+    width: 40px;
+    height: 5px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.22);
+    transition: background 0.2s;
+  }
+
+  .col-close-btn:hover::before {
+    background: rgba(124, 58, 237, 0.45);
   }
 
   .col-close-btn img {
     display: none;
-  }
-
-  .col-close-btn:hover {
-    background: rgba(124, 58, 237, 0.35);
   }
 
   /* "Show events" pill floats at the bottom when the sheet is closed */
@@ -202,6 +221,10 @@ body:has(.HomePage) {
     font-weight: 600;
     color: #7c3aed;
     gap: 8px;
+  }
+
+  .col-open-label {
+    display: inline;
   }
 
   .col-closed .col-open-btn {

--- a/frontend/src/Pages/Home/HomePage.css
+++ b/frontend/src/Pages/Home/HomePage.css
@@ -151,11 +151,13 @@ body:has(.HomePage) {
     bottom: 0;
     left: 0;
     width: 100vw;
-    height: 62vh;
-    max-height: 62vh;
-    border-top-left-radius: 18px;
-    border-top-right-radius: 18px;
-    box-shadow: 0 -6px 28px rgba(0, 0, 0, 0.22);
+    height: 65vh;
+    max-height: 65vh;
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    box-shadow:
+      0 -6px 28px rgba(0, 0, 0, 0.22),
+      0 -1px 0 rgba(124, 58, 237, 0.15);
     overflow: hidden;
   }
 
@@ -164,23 +166,42 @@ body:has(.HomePage) {
     transform: translateY(100%);
   }
 
-  /* Close affordance becomes a top-center grab handle (arrow points down) */
+  /* Close affordance: pill drag handle at top-center */
   .col-close-btn {
-    top: 8px;
+    top: 10px;
     right: 50%;
-    transform: translate(50%, 0) rotate(-90deg);
+    transform: translate(50%, 0);
+    width: 44px;
+    height: 5px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.2);
+    border: none;
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .col-close-btn img {
+    display: none;
+  }
+
+  .col-close-btn:hover {
+    background: rgba(124, 58, 237, 0.35);
   }
 
   /* "Show events" pill floats at the bottom when the sheet is closed */
   .col-open-btn {
     top: auto;
-    bottom: 16px;
+    bottom: 20px;
     left: 50%;
     width: auto;
-    height: 38px;
-    padding: 0 14px;
-    border-radius: 19px;
-    transform: translateX(-50%) translateY(8px);
+    height: 44px;
+    padding: 0 20px;
+    border-radius: 22px;
+    transform: translateX(-50%) translateY(10px);
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #7c3aed;
+    gap: 8px;
   }
 
   .col-closed .col-open-btn {
@@ -190,11 +211,11 @@ body:has(.HomePage) {
   .Create-Event-Button {
     left: 50%;
     transform: translateX(-50%);
-    bottom: calc(62vh + 12px);
+    bottom: calc(65vh + 14px);
   }
 
   .col-closed .Create-Event-Button {
     left: 50%;
-    bottom: 64px;
+    bottom: 76px;
   }
 }

--- a/frontend/src/Pages/Home/HomePage.jsx
+++ b/frontend/src/Pages/Home/HomePage.jsx
@@ -68,6 +68,7 @@ export default function HomePage() {
         title="Open event panel"
         aria-label="Open event panel">
         <img src={HamburgerIcon} alt="" />
+        <span className="col-open-label">Events</span>
       </button>
 
       <div className="Create-Event-Button">

--- a/frontend/src/Pages/Landing/Landing.css
+++ b/frontend/src/Pages/Landing/Landing.css
@@ -341,8 +341,71 @@ main {
   }
 }
 
+@media (max-width: 480px) {
+  .hero-section {
+    padding: 0 1rem;
+  }
+
+  .hero-title {
+    font-size: 2.1rem;
+  }
+
+  .hero-subtitle {
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .cta-button {
+    padding: 0.85rem 1.5rem;
+    font-size: 1rem;
+    display: block;
+    max-width: 280px;
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  .feature-text h2,
+  .feature-content h2 {
+    font-size: 1.55rem;
+  }
+
+  .feature-text p,
+  .feature-content p {
+    font-size: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .feature {
+    padding: 1.5rem;
+  }
+
+  .newsletter-section {
+    padding: 2.5rem 1rem;
+  }
+
+  .newsletter-content h2 {
+    font-size: 1.6rem;
+  }
+
+  .newsletter-content p {
+    font-size: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .newsletter-form input {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .footer-links {
+    gap: 1.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
 @media (max-width: 420px) {
   .hero-title {
-    font-size: 2rem;
+    font-size: 1.85rem;
   }
 }

--- a/frontend/src/Pages/Profile/Profile.css
+++ b/frontend/src/Pages/Profile/Profile.css
@@ -674,6 +674,21 @@
   color: #a78bfa;
 }
 
+@media (max-width: 480px) {
+  .profile-layout {
+    padding: 1rem 0.75rem 3rem;
+    gap: 1.25rem;
+  }
+
+  .profile-sidebar-card {
+    padding: 1.5rem 1rem;
+  }
+
+  .profile-back-wrapper {
+    padding: 1rem 0.75rem 0;
+  }
+}
+
 /* Add to Profile.css — delete account button in sidebar */
 .profile-btn--delete-account {
   width: 100%;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,3 +51,22 @@ h5,
 h6 {
   font-weight: 600;
 }
+
+/* ── Mobile UX globals ── */
+button,
+a {
+  touch-action: manipulation;
+}
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+@media (max-width: 768px) {
+  /* Prevent iOS auto-zoom on form inputs (font-size < 16px triggers it) */
+  input,
+  textarea,
+  select {
+    font-size: max(16px, 1em);
+  }
+}


### PR DESCRIPTION
## Summary

- **Auth persistence**: Users no longer get logged out on page refresh. Added a `localStorage` session layer (14-min TTL matching the JWT expiry) so tokens survive refreshes even when the HttpOnly cookie refresh fails cross-domain in production. Login/register saves the session; logout clears it; page load restores from localStorage instantly and refreshes the cookie in the background.

- **Navbar mobile hamburger**: At ≤ 768px, all desktop nav links/buttons are hidden and replaced with an animated hamburger button that opens a full-width slide-down drawer with Explore, Clubs, and all auth actions. Closes on route change or outside tap.

- **SignIn/Registration modals**: Slide up as bottom sheets on small phones (≤ 480px / ≤ 560px) — full-width, rounded top corners, larger tap targets, registration grid collapses to single column.

- **CreateEventModal**: Bottom-sheet on phones ≤ 520px; datetime grid collapses to single column; action buttons go full-width.

- **Home page bottom sheet**: Improved drag handle (large tap target), "Events" label on the open button, 65vh height, cleaner rounded corners.

- **Clubs page**: Header stacks vertically, cards go single-column, tighter padding at ≤ 640px.

- **Explore page**: Fixed missing `padding-top: var(--nav-h)` (content was hidden behind navbar). Toolbar stacks to full-width controls at ≤ 600px.

- **Landing, EventDetails, Profile**: Additional breakpoints for small phones.

- **Global**: `touch-action: manipulation` on buttons/links, `-webkit-tap-highlight-color: transparent`, `font-size: max(16px, 1em)` on inputs to prevent iOS auto-zoom.

## Test plan
- [ ] Log in, refresh page — should stay logged in
- [ ] On mobile (≤ 768px): hamburger menu opens/closes, all nav links work
- [ ] Sign In and Registration modals slide up from bottom on small screens
- [ ] Home page map: bottom sheet opens/closes with drag handle and "Events" button
- [ ] Clubs, Explore, EventDetails pages render correctly on 375px viewport
- [ ] Logout clears session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgaYxWeFzkng97bkGuf4yu

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgaYxWeFzkng97bkGuf4yu)_